### PR TITLE
Add support for custom DotEnv file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ target/
 # https://docs.docker.com/compose/extends/
 docker-compose.override.yml
 
+# https://docs.docker.com/compose/environment-variables/#using-the---env-file--option
+.env.custom
+
 *.tar
 data/
 .vscode/tags

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
 
 ## Setup
 
+### Customize DotEnv (.env) file
+
+Environment specific configurations can be done in the `.env.custom` file. It will be located in the root directory of the Sentry installation.
+
+By default, there exists no `.env.custom` file. In this case, you can manually add this file by copying the `.env` file to a new `.env.custom` file and adjust your settings in the `.env.custom` file.
+
+Please keep in mind to check the `.env` file for changes, when you perform an upgrade of Sentry, so that you can adjust your `.env.custom` accordingly, if required.
+
+### Installation
+
 To get started with all the defaults, simply clone the repo and run `./install.sh` in your local check-out. Sentry uses Python 3 by default since December 4th, 2020 and Sentry 21.1.0 is the last version to support Python 2.
 
 During the install, a prompt will ask if you want to create a user account. If you require that the install not be blocked by the prompt, run `./install.sh --no-user-prompt`.

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -12,7 +12,12 @@ else
   cd "$(dirname $0)"  # assume we're a test script or some such
 fi
 
-_ENV="$(realpath ../.env)"
+# Allow `.env` overrides using the `.env.custom` file
+if [[ -f "../.env.custom" ]]; then
+  _ENV="$(realpath ../.env.custom)"
+else
+  _ENV="$(realpath ../.env)"
+fi
 
 # Read .env for default values with a tip o' the hat to https://stackoverflow.com/a/59831605/90297
 t=$(mktemp) && export -p > "$t" && set -a && . $_ENV && set +a && . "$t" && rm "$t" && unset t
@@ -26,7 +31,7 @@ else
 fi
 
 dc_base="$(docker compose version &> /dev/null && echo 'docker compose' || echo 'docker-compose')"
-dc="$dc_base --ansi never"
+dc="$dc_base --ansi never --env-file ${_ENV}"
 dcr="$dc run --rm"
 
 # A couple of the config files are referenced from other subscripts, so they

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -19,7 +19,11 @@ else
   echo ""
   echo "You're all done! Run the following command to get Sentry running:"
   echo ""
+  if [[ "${_ENV}" =~ ".env.custom" ]]; then
+  echo "  $dc_base --env-file ${_ENV} up -d"
+  else
   echo "  $dc_base up -d"
+  fi
   echo ""
   echo "-----------------------------------------------------------------"
   echo ""


### PR DESCRIPTION
This merge request will...

- add support for a customizable `.env` file
- add `.env.custom` to `.gitignore`, so that Git will ignore changes regarding this file
- add a note regarding the customizable `.env.custom` file to the readme

Motivation:
The `.env`file provides environment specific configurations, which can be always different at each installation. Docker uses by default the `.env` file. Using the parameter `--env-file` [1], you can define a custom file.

Usually, you want to have your installation clean, so Git should not report any unstaged / uncommitted changes, when you change environment specific settings and run `git status`.

Since the `.env` file is currenlty in Git, we need a custom file, which is not in Git.

Refs:
- [1] https://docs.docker.com/compose/environment-variables/#using-the---env-file--option