### PR TITLE
fix: make minimum docker-compose version compatible with version 2.x.x

### DIFF
--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -4,7 +4,7 @@ source "$(dirname $0)/_min-requirements.sh"
 
 DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
 # Do NOT use $dc instead of `docker-compose` below as older versions don't support certain options and fail
-COMPOSE_VERSION=$(docker-compose --version | sed 's/docker-compose version \(.\{1,\}\),.*/\1/')
+COMPOSE_VERSION=$(docker-compose --version | sed 's/[dD]ocker[- ][cC]ompose version \([^,]\{1,\}\),\?.*/\1/')
 RAM_AVAILABLE_IN_DOCKER=$(docker run --rm busybox free -m 2>/dev/null | awk '/Mem/ {print $2}');
 CPU_AVAILABLE_IN_DOCKER=$(docker run --rm busybox nproc --all);
 


### PR DESCRIPTION
`docker-compose --version` output changed with version 2. I changed the sed to reflect the changes

```
$ docker-compose --version
docker-compose version 1.25.0, build 0a186604
$ docker-compose --version | sed 's/[dD]ocker[- ][cC]ompose version \([^,]\{1,\}\),\?.*/\1/'
1.25.0
```
```
$ docker-compose --version                                                                  
Docker Compose version 2.0.1
$ docker-compose --version | sed 's/[dD]ocker[- ][cC]ompose version \([^,]\{1,\}\),\?.*/\1/'
2.0.1
```

Signed-off-by: Cyril Duval <cyril@fayak.com>