### PR TITLE
Do more migrating to Docker Compose v2

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -34,7 +34,7 @@ body:
       placeholder: |-
         e.g.:
         - latest install logs: `ls -1 sentry_install_log-*.txt | tail -1 | xargs cat`
-        - `docker-compose logs` output
+        - `docker compose logs` output
     validations:
       required: true
   - type: markdown

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -30,6 +30,7 @@ else
   _endgroup=""
 fi
 
+# Some environments still use `docker-compose` even for Docker Compose v2.
 dc_base="$(docker compose version &> /dev/null && echo 'docker compose' || echo 'docker-compose')"
 dc="$dc_base --ansi never --env-file ${_ENV}"
 dcr="$dc run --rm"

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -2,30 +2,28 @@ echo "${_group}Checking minimum requirements ..."
 
 source "$(dirname $0)/_min-requirements.sh"
 
-DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
-# Get semantic version of Docker Compose v2
-if docker compose version &>/dev/null; then
-  COMPOSE_VERSION=$(docker compose version --short | sed 's/v\{0,1\}\(.\{1,\}\)/\1/')
-else
-  # Do NOT use $dc instead of `docker-compose` below as older versions don't support certain options and fail
-  COMPOSE_VERSION=$(docker-compose --version | sed 's/docker-compose version \(.\{1,\}\),.*/\1/')
-fi
-RAM_AVAILABLE_IN_DOCKER=$(docker run --rm busybox free -m 2>/dev/null | awk '/Mem/ {print $2}');
-CPU_AVAILABLE_IN_DOCKER=$(docker run --rm busybox nproc --all);
-
 # Compare dot-separated strings - function below is inspired by https://stackoverflow.com/a/37939589/808368
 function ver () { echo "$@" | awk -F. '{ printf("%d%03d%03d", $1,$2,$3); }'; }
 
+DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
 if [[ "$(ver $DOCKER_VERSION)" -lt "$(ver $MIN_DOCKER_VERSION)" ]]; then
   echo "FAIL: Expected minimum Docker version to be $MIN_DOCKER_VERSION but found $DOCKER_VERSION"
   exit 1
 fi
 
-if [[ "$(ver $COMPOSE_VERSION)" -lt "$(ver $MIN_COMPOSE_VERSION)" ]]; then
-  echo "FAIL: Expected minimum docker-compose version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
-  exit 1
+if docker compose version &>/dev/null; then
+  # If `docker compose` exists then it's guaranteed to be Docker Compose v2, which is good enough for us.
+  true
+else
+  # If we have `docker-compose` instead then it could be either v1 or v2 (also, use portable sed).
+  COMPOSE_VERSION=$(docker-compose version | head -n1 | sed 's/^.* version:\{0,1\} v\{0,1\}\(.\{1,\}\),.*$/\1/')
+  if [[ "$(ver $COMPOSE_VERSION)" -lt "$(ver $MIN_COMPOSE_VERSION)" ]]; then
+    echo "FAIL: Expected minimum docker-compose version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
+    exit 1
+  fi
 fi
 
+CPU_AVAILABLE_IN_DOCKER=$(docker run --rm busybox nproc --all);
 if [[ "$CPU_AVAILABLE_IN_DOCKER" -lt "$MIN_CPU_HARD" ]]; then
   echo "FAIL: Required minimum CPU cores available to Docker is $MIN_CPU_HARD, found $CPU_AVAILABLE_IN_DOCKER"
   exit 1
@@ -33,6 +31,7 @@ elif [[ "$CPU_AVAILABLE_IN_DOCKER" -lt "$MIN_CPU_SOFT" ]]; then
   echo "WARN: Recommended minimum CPU cores available to Docker is $MIN_CPU_SOFT, found $CPU_AVAILABLE_IN_DOCKER"
 fi
 
+RAM_AVAILABLE_IN_DOCKER=$(docker run --rm busybox free -m 2>/dev/null | awk '/Mem/ {print $2}');
 if [[ "$RAM_AVAILABLE_IN_DOCKER" -lt "$MIN_RAM_HARD" ]]; then
   echo "FAIL: Required minimum RAM available to Docker is $MIN_RAM_HARD MB, found $RAM_AVAILABLE_IN_DOCKER MB"
   exit 1

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -16,7 +16,8 @@ if docker compose version &>/dev/null; then
   true
 else
   # If we have `docker-compose` instead then it could be either v1 or v2 (also, use portable sed).
-  COMPOSE_VERSION=$(docker-compose version | head -n1 | sed 's/^.* version:\{0,1\} v\{0,1\}\(.\{1,\}\),.*$/\1/')
+  # See https://github.com/getsentry/self-hosted/issues/1132#issuecomment-982823712 ff. for regex testing.
+  COMPOSE_VERSION=$(docker-compose version | head -n1 | sed -E 's/^.* version:? v?([0-9.]+),?.*$/\1/'
   if [[ "$(ver $COMPOSE_VERSION)" -lt "$(ver $MIN_COMPOSE_VERSION)" ]]; then
     echo "FAIL: Expected minimum docker-compose version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
     exit 1

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -17,7 +17,7 @@ if docker compose version &>/dev/null; then
 else
   # If we have `docker-compose` instead then it could be either v1 or v2 (also, use portable sed).
   # See https://github.com/getsentry/self-hosted/issues/1132#issuecomment-982823712 ff. for regex testing.
-  COMPOSE_VERSION=$(docker-compose version | head -n1 | sed -E 's/^.* version:? v?([0-9.]+),?.*$/\1/'
+  COMPOSE_VERSION=$(docker-compose version | head -n1 | sed -E 's/^.* version:? v?([0-9.]+),?.*$/\1/')
   if [[ "$(ver $COMPOSE_VERSION)" -lt "$(ver $MIN_COMPOSE_VERSION)" ]]; then
     echo "FAIL: Expected minimum docker-compose version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
     exit 1

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -20,7 +20,7 @@ cleanup () {
     echo "An error occurred, caught SIG$1 on line $2";
 
     if [[ -n "$MINIMIZE_DOWNTIME" ]]; then
-      echo "*NOT* cleaning up, to clean your environment run \"docker-compose stop\"."
+      echo "*NOT* cleaning up, to clean your environment run \"docker compose stop\"."
     else
       echo "Cleaning up..."
     fi

--- a/install/parse-cli.sh
+++ b/install/parse-cli.sh
@@ -4,7 +4,7 @@ show_help() {
   cat <<EOF
 Usage: $0 [options]
 
-Install Sentry with docker-compose.
+Install Sentry with `docker compose`.
 
 Options:
  -h, --help             Show this message and exit.

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -6,7 +6,7 @@ if [[ -n "${CI:-}" || "${SKIP_USER_PROMPT:-0}" == 1 ]]; then
   echo "Did not prompt for user creation due to non-interactive shell."
   echo "Run the following command to create one yourself (recommended):"
   echo ""
-  echo "  docker-compose run --rm web createuser"
+  echo "  docker compose run --rm web createuser"
   echo ""
 else
   $dcr web upgrade

--- a/install/update-docker-images.sh
+++ b/install/update-docker-images.sh
@@ -1,10 +1,11 @@
 echo "${_group}Fetching and updating Docker images ..."
 
-# We tag locally built images with an '-onpremise-local' suffix. docker-compose
-# pull tries to pull these too and shows a 404 error on the console which is
-# confusing and unnecessary. To overcome this, we add the stderr>stdout
-# redirection below and pass it through grep, ignoring all lines having this
-# '-onpremise-local' suffix.
+# We tag locally built images with an '-onpremise-local' suffix. `docker
+# compose pull` tries to pull these too and shows a 404 error on the console
+# which is confusing and unnecessary. To overcome this, we add the
+# stderr>stdout redirection below and pass it through grep, ignoring all lines
+# having this '-onpremise-local' suffix.
+
 $dc pull -q --ignore-pull-failures 2>&1 | grep -v -- -onpremise-local || true
 
 # We may not have the set image on the repo (local images) so allow fails

--- a/reset.sh
+++ b/reset.sh
@@ -44,7 +44,7 @@ confirm "☠️  Warning! 😳 This is highly destructive! 😱 Are you sure you
 echo "Okay ... good luck! 😰"
 
 # Hit the reset button.
-docker-compose down --volumes --remove-orphans --rmi local
+docker compose down --volumes --remove-orphans --rmi local
 
 # Remove any remaining (likely external) volumes with name matching 'sentry-.*'.
 for volume in $(docker volume list --format '{{ .Name }}' | grep '^sentry-'); do


### PR DESCRIPTION
The big thing here is a fix for #1132. I did a grep for `docker-compose` and cleaned up the rest of the instances. The one question I had is in CI tests ... as I read it we still need `docker-compose` there so we can test v1, which we do still want to support for now.