### PR TITLE
Self-hosted Sentry is not vulnerable to log4shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ Where you replace `83b1380` with the sha you want to use.
 
 [build-status-image]: https://github.com/getsentry/self-hosted/workflows/test/badge.svg
 [build-status-url]: https://git.io/JUYkh
+


### PR DESCRIPTION
This is a dummy PR to work around limitations with the automated changelog system we are using. Please see https://github.com/getsentry/self-hosted/issues/1196 for discussion.