### PR TITLE
Deprecated /docker-entrypoint.sh call

### DIFF
--- a/postgres/postgres-entrypoint.sh
+++ b/postgres/postgres-entrypoint.sh
@@ -43,4 +43,4 @@ if [ "$1" = 'postgres' ]; then
     cdc_setup_hba_conf
     bind_wal2json
 fi
-exec /docker-entrypoint.sh "$@"
+exec docker-entrypoint.sh "$@"

--- a/postgres/postgres-entrypoint.sh
+++ b/postgres/postgres-entrypoint.sh
@@ -43,4 +43,4 @@ if [ "$1" = 'postgres' ]; then
     cdc_setup_hba_conf
     bind_wal2json
 fi
-exec docker-entrypoint.sh "$@"
+exec /usr/local/bin/docker-entrypoint.sh "$@"


### PR DESCRIPTION
Link /docker-entrypoint.sh is depraceted in newer postgres versions
https://github.com/docker-library/postgres/blob/3bb48045b4dc5df24bf2271c679f7a4e9efcbe6e/9.6/stretch/Dockerfile