### PR TITLE
Install: setup umask

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,8 @@ if [[ -n "$MSYSTEM" ]]; then
   exit 1
 fi
 
+umask 002
+
 source "$(dirname $0)/install/_lib.sh"  # does a `cd .../install/`, among other things
 
 source dc-detect-version.sh


### PR DESCRIPTION
Setup default [`umask`](https://en.wikipedia.org/wiki/Umask), otherwise files created with permissions that containers later can't read.

```
    !! Configuration error: ConfigurationError("PermissionError: [Errno 13]
    Unable to load configuration file (Permission denied):
    '/etc/sentry/sentry.conf.py'",)
```

To reproduce, try:

```
git checkout 21.6.3 
umask 0007
./install.sh
```

```
root@docker2 sentry/21.6.3# ls -l sentry/sentry.conf.py
-rw-rw---- 1 root root 7.4K Dec 25 03:18 sentry/sentry.conf.py
```

also known to be broken with `21.5.0` and `9.1.2`, i.e the versions noted in hard stops:
- https://develop.sentry.dev/self-hosted/releases/#hard-stops

so, perhaps carry the fix to those branches as well