### PR TITLE
Bump nginx:1.21.5-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -328,7 +328,7 @@ services:
     <<: *restart_policy
     ports:
       - "$SENTRY_BIND:80/tcp"
-    image: "nginx:1.21.4-alpine"
+    image: "nginx:1.21.5-alpine"
     volumes:
       - type: bind
         read_only: true


### PR DESCRIPTION
```
Changes with nginx 1.21.5                                        28 Dec 2021

    *) Change: now nginx is built with the PCRE2 library by default.

    *) Change: now nginx always uses sendfile(SF_NODISKIO) on FreeBSD.

    *) Feature: support for sendfile(SF_NOCACHE) on FreeBSD.

    *) Feature: the $ssl_curve variable.

    *) Bugfix: connections might hang when using HTTP/2 without SSL with the
       "sendfile" and "aio" directives.
```