### PR TITLE
Add CI compose version 1.29.2 / 2.2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,11 @@ jobs:
         include:
           - compose_version: '1.28.0'
             compose_path: '/usr/local/bin'
+          - compose_version: '1.29.2'
+            compose_path: '/usr/local/bin'
           - compose_version: 'v2.0.1'
+            compose_path: '/usr/local/lib/docker/cli-plugins'
+          - compose_version: 'v2.2.3'
             compose_path: '/usr/local/lib/docker/cli-plugins'
     steps:
       - name: Checkout

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -2,7 +2,7 @@ echo "${_group}Creating additional Kafka topics ..."
 
 # NOTE: This step relies on `kafka` being available from the previous `snuba-api bootstrap` step
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
-EXISTING_KAFKA_TOPICS=$($dcr kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
+EXISTING_KAFKA_TOPICS=$($dcr --no-TTY kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
 NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events"
 for topic in $NEEDED_KAFKA_TOPICS; do
   if ! echo "$EXISTING_KAFKA_TOPICS" | grep -wq $topic; then

--- a/install/relay-credentials.sh
+++ b/install/relay-credentials.sh
@@ -14,7 +14,7 @@ if [[ ! -f "$RELAY_CREDENTIALS_JSON" ]]; then
   # creating an empty credentials file before relay runs.
 
   $dcr \
-    --no-deps \
+    --no-deps --no-TTY \
     --volume "$(pwd)/$RELAY_CONFIG_YML:/tmp/config.yml" \
     relay --config /tmp credentials generate --stdout \
     > "$RELAY_CREDENTIALS_JSON"


### PR DESCRIPTION
~~If it's causing issues (https://github.com/getsentry/self-hosted/issues/1133#issuecomment-1006120915) why should we stick to it?~~

~~Also while we're here let's bump docker-compose 1.x version to latest release.~~

So this PR got changed in the way and at last min/max 1.x and 2.x versions of docker-compose added to CI as suggested by @chadwhitacre in https://github.com/getsentry/self-hosted/pull/1251#discussion_r787960586

Also because of recent changes in 2.2.3 (https://github.com/docker/compose/pull/9035) `-T` had to be added to some scripts using `$dcr` where output of it was getting used.
```
  -T, --no-TTY                Disable pseudo-noTty allocation. By default docker compose run allocates a TTY
```