### PR TITLE
Clean up relay credentials generation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ source check-minimum-requirements.sh
 source turn-things-off.sh
 source create-docker-volumes.sh
 source ensure-files-from-examples.sh
+source ensure-relay-credentials.sh
 source generate-secret-key.sh
 source replace-tsdb.sh
 source update-docker-images.sh
@@ -31,6 +32,5 @@ source create-kafka-topics.sh
 source upgrade-postgres.sh
 source set-up-and-migrate-database.sh
 source migrate-file-storage.sh
-source relay-credentials.sh
 source geoip.sh
 source wrap-up.sh

--- a/install/ensure-relay-credentials-test.sh
+++ b/install/ensure-relay-credentials-test.sh
@@ -9,7 +9,7 @@ test ! -f $cfg
 test ! -f $creds
 
 # Running the install script adds them.
-source relay-credentials.sh
+source ensure-relay-credentials.sh
 test -f $cfg
 test -f $creds
 test "$(jq -r 'keys[2]' $creds)" = "secret_key"
@@ -17,7 +17,7 @@ test "$(jq -r 'keys[2]' $creds)" = "secret_key"
 # If the files exist we don't touch it.
 echo GARBAGE > $cfg
 echo MOAR GARBAGE > $creds
-source relay-credentials.sh
+source ensure-relay-credentials.sh
 test "$(cat $cfg)" = "GARBAGE"
 test "$(cat $creds)" = "MOAR GARBAGE"
 

--- a/install/ensure-relay-credentials.sh
+++ b/install/ensure-relay-credentials.sh
@@ -1,0 +1,34 @@
+echo "${_group}Ensuring Relay credentials ..."
+
+RELAY_CONFIG_YML="../relay/config.yml"
+RELAY_CREDENTIALS_JSON="../relay/credentials.json"
+
+ensure_file_from_example $RELAY_CONFIG_YML
+
+if [[ -f "$RELAY_CREDENTIALS_JSON" ]]; then
+  echo "$RELAY_CREDENTIALS_JSON already exists, skipped creation."
+else
+
+  # There are a couple gotchas here:
+  #
+  # 1. We need to use a tmp file because if we redirect output directly to
+  #    credentials.json, then the shell will create an empty file that relay
+  #    will then try to read from (regardless of options such as --stdout or
+  #    --overwrite) and fail because it is empty.
+  #
+  # 2. We need to use -T to avoid additional garbage output cluttering
+  #    credentials.json under Docker Compose 1.x and 2.2.3+. Note that the
+  #    long opt --no-tty doesn't exist in Docker Compose 1.
+
+  creds="$dcr --no-deps -T relay credentials"
+  $creds generate --stdout > "$RELAY_CREDENTIALS_JSON".tmp
+  mv "$RELAY_CREDENTIALS_JSON".tmp "$RELAY_CREDENTIALS_JSON"
+  if ! grep -q Credentials <($creds show); then
+    # Let's fail early if creds failed, to make debugging easier.
+    echo "Failed to create relay credentials in $RELAY_CREDENTIALS_JSON."
+    exit 1
+  fi
+  echo "Relay credentials written to $RELAY_CREDENTIALS_JSON."
+fi
+
+echo "${_endgroup}"


### PR DESCRIPTION
This is a follow-up to #1273, and it should get CI back on track on `master`.