### PR TITLE
Run CI every night

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
       - "master"
       - "release/**"
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 defaults:
   run:
     shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           # Also test plugin installation here
           echo "sentry-auth-oidc" >> sentry/requirements.txt
           ./install.sh --minimize-downtime
+          cat /proc/sys/kernel/random/entropy_avail
           ./_integration-test/run.sh
 
       - name: Inspect failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,6 @@ jobs:
           # Also test plugin installation here
           echo "sentry-auth-oidc" >> sentry/requirements.txt
           ./install.sh --minimize-downtime
-          cat /proc/sys/kernel/random/entropy_avail
           ./_integration-test/run.sh
 
       - name: Inspect failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - "release/**"
   pull_request:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '1 0 * * *'
 defaults:
   run:
     shell: bash

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -39,6 +39,7 @@ trap_with_arg teardown ERR INT TERM EXIT
 echo "${_endgroup}"
 
 echo "${_group}Starting Sentry for tests ..."
+cat /proc/sys/kernel/random/entropy_avail
 # Disable beacon for e2e tests
 echo 'SENTRY_BEACON=False' >> $SENTRY_CONFIG_PY
 echo y | $dcr web createuser --force-update --superuser --email $TEST_USER --password $TEST_PASS

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -39,7 +39,6 @@ trap_with_arg teardown ERR INT TERM EXIT
 echo "${_endgroup}"
 
 echo "${_group}Starting Sentry for tests ..."
-cat /proc/sys/kernel/random/entropy_avail
 # Disable beacon for e2e tests
 echo 'SENTRY_BEACON=False' >> $SENTRY_CONFIG_PY
 echo y | $dcr web createuser --force-update --superuser --email $TEST_USER --password $TEST_PASS


### PR DESCRIPTION
I think this helps us running to catch any errors sooner than a PR comes up as this repository is not having so many changes and there may be many days without a CI running, and who doesn't like more testing? :)

We may want to change the time though.