### PR TITLE
Proof of Concept: Use Vectorized Redpanda instead of Kafka + Zookeeper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ x-sentry-defaults: &sentry_defaults
   depends_on:
     redis:
       <<: *depends_on-healthy
-    redpanda:
+    kafka:
       <<: *depends_on-healthy
     # kafka:
     #   <<: *depends_on-healthy
@@ -76,9 +76,9 @@ x-snuba-defaults: &snuba_defaults
   depends_on:
     clickhouse:
       <<: *depends_on-healthy
+    # kafka:
+    #   <<: *depends_on-healthy
     kafka:
-      <<: *depends_on-healthy
-    redpanda:
       <<: *depends_on-healthy
     redis:
       <<: *depends_on-healthy
@@ -87,7 +87,7 @@ x-snuba-defaults: &snuba_defaults
     SNUBA_SETTINGS: docker
     CLICKHOUSE_HOST: clickhouse
     # DEFAULT_BROKERS: "kafka:9092"
-    DEFAULT_BROKERS: "redpanda:9092"
+    DEFAULT_BROKERS: "kafka:9092"
     REDIS_HOST: redis
     UWSGI_MAX_REQUESTS: "10000"
     UWSGI_DISABLE_LOGGING: "true"
@@ -189,30 +189,25 @@ services:
   #   healthcheck:
   #     <<: *healthcheck_defaults
   #     test: ["CMD-SHELL", "nc -z localhost 9092"]
-  redpanda:
+  kafka:
     image: "vectorized/redpanda:v21.11.8"
     command:
-      - redpanda
-      - start
-      - --smp
-      - '1'
-      - --reserve-memory
-      - 0M
+      - redpanda start
+      - --smp 1
+      - --reserve-memory 0M
       - --overprovisioned
-      - --node-id
-      - '0'
-      - --kafka-addr
-      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
-      - --advertise-kafka-addr
-      - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
+      - --node-id 0
+      - --kafka-addr 0.0.0.0:9092
+      - --advertise-kafka-addr kafka:9092
+      - --set redpanda.enable_transactions=true
+      - --set redpanda.enable_idempotence=true
       # NOTE: Please use the latest version here!
     image: docker.vectorized.io/vectorized/redpanda:v21.9.5
-    container_name: redpanda-1
     ports:
       - 9092:9092
-      - 29092:29092
     volumes:
       - "sentry-redpanda:/var/lib/redpanda/data"
+    healthcheck: { test: curl -f localhost:9644/v1/status/ready, interval: 1s, start_period: 30s }
   clickhouse:
     <<: *restart_policy
     image: "yandex/clickhouse-server:20.3.9.70"
@@ -379,7 +374,7 @@ services:
         source: ./geoip
         target: /geoip
     depends_on:
-      redpanda:
+      kafka:
         <<: *depends_on-healthy
       redis:
         <<: *depends_on-healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ x-sentry-defaults: &sentry_defaults
   depends_on:
     redis:
       <<: *depends_on-healthy
-    kafka:
+    redpanda:
       <<: *depends_on-healthy
     postgres:
       <<: *depends_on-healthy
@@ -74,7 +74,7 @@ x-snuba-defaults: &snuba_defaults
   depends_on:
     clickhouse:
       <<: *depends_on-healthy
-    kafka:
+    redpanda:
       <<: *depends_on-healthy
     redis:
       <<: *depends_on-healthy
@@ -82,7 +82,7 @@ x-snuba-defaults: &snuba_defaults
   environment:
     SNUBA_SETTINGS: docker
     CLICKHOUSE_HOST: clickhouse
-    DEFAULT_BROKERS: "kafka:9092"
+    DEFAULT_BROKERS: "redpanda:9092"
     REDIS_HOST: redis
     UWSGI_MAX_REQUESTS: "10000"
     UWSGI_DISABLE_LOGGING: "true"
@@ -169,7 +169,7 @@ services:
   #   healthcheck:
   #     <<: *healthcheck_defaults
   #     test: ["CMD-SHELL", "nc -z localhost 9092"]
-  kafka:
+  redpanda:
     image: "vectorized/redpanda:v21.11.8"
     command:
       - redpanda start
@@ -178,7 +178,7 @@ services:
       - --overprovisioned
       - --node-id 0
       - --kafka-addr 0.0.0.0:9092
-      - --advertise-kafka-addr kafka:9092
+      - --advertise-kafka-addr redpanda:9092
       - --set redpanda.enable_transactions=true
       - --set redpanda.enable_idempotence=true
       # NOTE: Please use the latest version here!
@@ -354,7 +354,7 @@ services:
         source: ./geoip
         target: /geoip
     depends_on:
-      kafka:
+      redpanda:
         <<: *depends_on-healthy
       redis:
         <<: *depends_on-healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ x-sentry-defaults: &sentry_defaults
       <<: *depends_on-healthy
     kafka:
       <<: *depends_on-healthy
-    # kafka:
-    #   <<: *depends_on-healthy
     postgres:
       <<: *depends_on-healthy
     memcached:
@@ -76,8 +74,6 @@ x-snuba-defaults: &snuba_defaults
   depends_on:
     clickhouse:
       <<: *depends_on-healthy
-    # kafka:
-    #   <<: *depends_on-healthy
     kafka:
       <<: *depends_on-healthy
     redis:
@@ -86,7 +82,6 @@ x-snuba-defaults: &snuba_defaults
   environment:
     SNUBA_SETTINGS: docker
     CLICKHOUSE_HOST: clickhouse
-    # DEFAULT_BROKERS: "kafka:9092"
     DEFAULT_BROKERS: "kafka:9092"
     REDIS_HOST: redis
     UWSGI_MAX_REQUESTS: "10000"
@@ -147,23 +142,8 @@ services:
         read_only: true
         source: ./postgres/
         target: /opt/sentry/
-  # zookeeper:
-  #   <<: *restart_policy
-  #   image: "confluentinc/cp-zookeeper:5.5.0"
-  #   environment:
-  #     ZOOKEEPER_CLIENT_PORT: "2181"
-  #     CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-  #     ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: "WARN"
-  #     ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: "WARN"
-  #     KAFKA_OPTS: "-Dzookeeper.4lw.commands.whitelist=ruok"
-  #   volumes:
-  #     - "sentry-zookeeper:/var/lib/zookeeper/data"
-  #     - "sentry-zookeeper-log:/var/lib/zookeeper/log"
-  #     - "sentry-secrets:/etc/zookeeper/secrets"
-  #   healthcheck:
-  #     <<: *healthcheck_defaults
-  #     test:
-  #       ["CMD-SHELL", 'echo "ruok" | nc -w 2 -q 2 localhost 2181 | grep imok']
+  # TODO: Migrate config settings over to redpanda flags
+  #
   # kafka:
   #   <<: *restart_policy
   #   depends_on:
@@ -390,10 +370,6 @@ volumes:
     external: true
   sentry-redpanda:
     external: true
-  # sentry-zookeeper:
-  #   external: true
-  # sentry-kafka:
-  #   external: true
   sentry-clickhouse:
     external: true
   sentry-symbolicator:
@@ -402,7 +378,5 @@ volumes:
   # These store ephemeral data that needn't persist across restarts.
   sentry-secrets:
   sentry-smtp:
-  # sentry-zookeeper-log:
-  # sentry-kafka-log:
   sentry-smtp-log:
   sentry-clickhouse-log:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,10 @@ x-sentry-defaults: &sentry_defaults
   depends_on:
     redis:
       <<: *depends_on-healthy
-    kafka:
+    redpanda:
       <<: *depends_on-healthy
+    # kafka:
+    #   <<: *depends_on-healthy
     postgres:
       <<: *depends_on-healthy
     memcached:
@@ -76,13 +78,16 @@ x-snuba-defaults: &snuba_defaults
       <<: *depends_on-healthy
     kafka:
       <<: *depends_on-healthy
+    redpanda:
+      <<: *depends_on-healthy
     redis:
       <<: *depends_on-healthy
   image: "$SNUBA_IMAGE"
   environment:
     SNUBA_SETTINGS: docker
     CLICKHOUSE_HOST: clickhouse
-    DEFAULT_BROKERS: "kafka:9092"
+    # DEFAULT_BROKERS: "kafka:9092"
+    DEFAULT_BROKERS: "redpanda:9092"
     REDIS_HOST: redis
     UWSGI_MAX_REQUESTS: "10000"
     UWSGI_DISABLE_LOGGING: "true"
@@ -142,48 +147,72 @@ services:
         read_only: true
         source: ./postgres/
         target: /opt/sentry/
-  zookeeper:
-    <<: *restart_policy
-    image: "confluentinc/cp-zookeeper:5.5.0"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: "2181"
-      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-      ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: "WARN"
-      ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: "WARN"
-      KAFKA_OPTS: "-Dzookeeper.4lw.commands.whitelist=ruok"
+  # zookeeper:
+  #   <<: *restart_policy
+  #   image: "confluentinc/cp-zookeeper:5.5.0"
+  #   environment:
+  #     ZOOKEEPER_CLIENT_PORT: "2181"
+  #     CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
+  #     ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: "WARN"
+  #     ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: "WARN"
+  #     KAFKA_OPTS: "-Dzookeeper.4lw.commands.whitelist=ruok"
+  #   volumes:
+  #     - "sentry-zookeeper:/var/lib/zookeeper/data"
+  #     - "sentry-zookeeper-log:/var/lib/zookeeper/log"
+  #     - "sentry-secrets:/etc/zookeeper/secrets"
+  #   healthcheck:
+  #     <<: *healthcheck_defaults
+  #     test:
+  #       ["CMD-SHELL", 'echo "ruok" | nc -w 2 -q 2 localhost 2181 | grep imok']
+  # kafka:
+  #   <<: *restart_policy
+  #   depends_on:
+  #     zookeeper:
+  #       <<: *depends_on-healthy
+  #   image: "confluentinc/cp-kafka:5.5.0"
+  #   environment:
+  #     KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+  #     KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+  #     KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+  #     KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: "1"
+  #     KAFKA_LOG_RETENTION_HOURS: "24"
+  #     KAFKA_MESSAGE_MAX_BYTES: "50000000" #50MB or bust
+  #     KAFKA_MAX_REQUEST_SIZE: "50000000" #50MB on requests apparently too
+  #     CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
+  #     KAFKA_LOG4J_LOGGERS: "kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN"
+  #     KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
+  #     KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
+  #   volumes:
+  #     - "sentry-kafka:/var/lib/kafka/data"
+  #     - "sentry-kafka-log:/var/lib/kafka/log"
+  #     - "sentry-secrets:/etc/kafka/secrets"
+  #   healthcheck:
+  #     <<: *healthcheck_defaults
+  #     test: ["CMD-SHELL", "nc -z localhost 9092"]
+  redpanda:
+    image: "vectorized/redpanda:v21.11.8"
+    command:
+      - redpanda
+      - start
+      - --smp
+      - '1'
+      - --reserve-memory
+      - 0M
+      - --overprovisioned
+      - --node-id
+      - '0'
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
+      # NOTE: Please use the latest version here!
+    image: docker.vectorized.io/vectorized/redpanda:v21.9.5
+    container_name: redpanda-1
+    ports:
+      - 9092:9092
+      - 29092:29092
     volumes:
-      - "sentry-zookeeper:/var/lib/zookeeper/data"
-      - "sentry-zookeeper-log:/var/lib/zookeeper/log"
-      - "sentry-secrets:/etc/zookeeper/secrets"
-    healthcheck:
-      <<: *healthcheck_defaults
-      test:
-        ["CMD-SHELL", 'echo "ruok" | nc -w 2 -q 2 localhost 2181 | grep imok']
-  kafka:
-    <<: *restart_policy
-    depends_on:
-      zookeeper:
-        <<: *depends_on-healthy
-    image: "confluentinc/cp-kafka:5.5.0"
-    environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: "1"
-      KAFKA_LOG_RETENTION_HOURS: "24"
-      KAFKA_MESSAGE_MAX_BYTES: "50000000" #50MB or bust
-      KAFKA_MAX_REQUEST_SIZE: "50000000" #50MB on requests apparently too
-      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-      KAFKA_LOG4J_LOGGERS: "kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN"
-      KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
-      KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
-    volumes:
-      - "sentry-kafka:/var/lib/kafka/data"
-      - "sentry-kafka-log:/var/lib/kafka/log"
-      - "sentry-secrets:/etc/kafka/secrets"
-    healthcheck:
-      <<: *healthcheck_defaults
-      test: ["CMD-SHELL", "nc -z localhost 9092"]
+      - "sentry-redpanda:/var/lib/redpanda/data"
   clickhouse:
     <<: *restart_policy
     image: "yandex/clickhouse-server:20.3.9.70"
@@ -350,7 +379,7 @@ services:
         source: ./geoip
         target: /geoip
     depends_on:
-      kafka:
+      redpanda:
         <<: *depends_on-healthy
       redis:
         <<: *depends_on-healthy
@@ -364,10 +393,12 @@ volumes:
     external: true
   sentry-redis:
     external: true
-  sentry-zookeeper:
+  sentry-redpanda:
     external: true
-  sentry-kafka:
-    external: true
+  # sentry-zookeeper:
+  #   external: true
+  # sentry-kafka:
+  #   external: true
   sentry-clickhouse:
     external: true
   sentry-symbolicator:
@@ -376,7 +407,7 @@ volumes:
   # These store ephemeral data that needn't persist across restarts.
   sentry-secrets:
   sentry-smtp:
-  sentry-zookeeper-log:
-  sentry-kafka-log:
+  # sentry-zookeeper-log:
+  # sentry-kafka-log:
   sentry-smtp-log:
   sentry-clickhouse-log:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,33 +142,6 @@ services:
         read_only: true
         source: ./postgres/
         target: /opt/sentry/
-  # TODO: Migrate config settings over to redpanda flags
-  #
-  # kafka:
-  #   <<: *restart_policy
-  #   depends_on:
-  #     zookeeper:
-  #       <<: *depends_on-healthy
-  #   image: "confluentinc/cp-kafka:5.5.0"
-  #   environment:
-  #     KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-  #     KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
-  #     KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-  #     KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: "1"
-  #     KAFKA_LOG_RETENTION_HOURS: "24"
-  #     KAFKA_MESSAGE_MAX_BYTES: "50000000" #50MB or bust
-  #     KAFKA_MAX_REQUEST_SIZE: "50000000" #50MB on requests apparently too
-  #     CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-  #     KAFKA_LOG4J_LOGGERS: "kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN"
-  #     KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
-  #     KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
-  #   volumes:
-  #     - "sentry-kafka:/var/lib/kafka/data"
-  #     - "sentry-kafka-log:/var/lib/kafka/log"
-  #     - "sentry-secrets:/etc/kafka/secrets"
-  #   healthcheck:
-  #     <<: *healthcheck_defaults
-  #     test: ["CMD-SHELL", "nc -z localhost 9092"]
   redpanda:
     image: "vectorized/redpanda:v21.11.8"
     command:

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,8 @@ source generate-secret-key.sh
 source replace-tsdb.sh
 source update-docker-images.sh
 source build-docker-images.sh
-source set-up-zookeeper.sh
+# source set-up-zookeeper.sh
+source set-up-redpanda.sh # maybe not necessary?
 source install-wal2json.sh
 source bootstrap-snuba.sh
 source create-kafka-topics.sh

--- a/install/create-docker-volumes.sh
+++ b/install/create-docker-volumes.sh
@@ -2,10 +2,11 @@ echo "${_group}Creating volumes for persistent storage ..."
 
 echo "Created $(docker volume create --name=sentry-clickhouse)."
 echo "Created $(docker volume create --name=sentry-data)."
-echo "Created $(docker volume create --name=sentry-kafka)."
+# echo "Created $(docker volume create --name=sentry-kafka)."
 echo "Created $(docker volume create --name=sentry-postgres)."
 echo "Created $(docker volume create --name=sentry-redis)."
 echo "Created $(docker volume create --name=sentry-symbolicator)."
-echo "Created $(docker volume create --name=sentry-zookeeper)."
+# echo "Created $(docker volume create --name=sentry-zookeeper)."
+echo "Created $(docker volume create --name=sentry-redpanda)."
 
 echo "${_endgroup}"

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -1,12 +1,18 @@
 echo "${_group}Creating additional Kafka topics ..."
 
+# TODO: Migrate existing kafka topics over to redpanda syntax
+
 # NOTE: This step relies on `kafka` being available from the previous `snuba-api bootstrap` step
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
-EXISTING_KAFKA_TOPICS=$($dcr -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
+# EXISTING_KAFKA_TOPICS=$($dcr -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
+
+EXISTING_KAFKA_TOPICS=""
+echo $EXISTING_KAFKA_TOPICS
+
 NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events"
 for topic in $NEEDED_KAFKA_TOPICS; do
   if ! echo "$EXISTING_KAFKA_TOPICS" | grep -wq $topic; then
-    $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092
+    $dcr redpanda topic create $topic --brokers kafka:9092
     echo ""
   fi
 done

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -12,7 +12,7 @@ echo $EXISTING_KAFKA_TOPICS
 NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events"
 for topic in $NEEDED_KAFKA_TOPICS; do
   if ! echo "$EXISTING_KAFKA_TOPICS" | grep -wq $topic; then
-    $dcr redpanda topic create $topic --brokers kafka:9092
+    $dcr redpanda topic create $topic --brokers redpanda:9092
     echo ""
   fi
 done

--- a/install/set-up-redpanda.sh
+++ b/install/set-up-redpanda.sh
@@ -1,0 +1,3 @@
+echo "${_group}Setting up Redpanda (WIP) ..."
+
+echo "${_endgroup}"

--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -7,7 +7,7 @@ logging:
 processing:
   enabled: true
   kafka_config:
-    - {name: "bootstrap.servers", value: "kafka:9092"}
+    - {name: "bootstrap.servers", value: "redpanda:9092"}
     - {name: "message.max.bytes", value: 50000000} # 50MB
   redis: redis://redis:6379
   geoip_path: "/geoip/GeoLite2-City.mmdb"

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -114,7 +114,7 @@ CACHES = {
 SENTRY_CACHE = "sentry.cache.redis.RedisCache"
 
 DEFAULT_KAFKA_OPTIONS = {
-    "bootstrap.servers": "kafka:9092",
+    "bootstrap.servers": "redpanda:9092",
     "message.max.bytes": 50000000,
     "socket.timeout.ms": 1000,
 }


### PR DESCRIPTION
This is still a Proof of Concept, but I set out to see how difficult it would be to use Vectorize Redpanda instead of Kafka, so far this has worked without any real issues, and the overall cpu and memory requirements would be lower than they are now, with the advantage of removing Java from the application.