### PR TITLE
Docker-Compose: Avoid setting hostname to ''

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
   smtp:
     <<: *restart_policy
     image: tianon/exim4
-    hostname: ${SENTRY_MAIL_HOST:-''}
+    hostname: ${SENTRY_MAIL_HOST:-}
     volumes:
       - "sentry-smtp:/var/spool/exim4"
       - "sentry-smtp-log:/var/log/exim4"


### PR DESCRIPTION
The hostname is literally set to `''`:

Before:
```
# docker-compose exec smtp hostname
''
```

After:
```
# docker-compose exec smtp hostname
c531c19841de
```