### PR TITLE
meta(gha): Deploy workflow enforce-license-compliance.yml

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   enforce-license-compliance:
+    if: github.repository_owner == 'getsentry'
     runs-on: ubuntu-latest
     steps:
       - name: 'Fetch FOSSA_API_KEY'


### PR DESCRIPTION
I are a bot, here to deploy [enforce-license-compliance.yml](https://github.com/getsentry/.github/blob/36d1230813c1e3344703382a744d151ba2d4b508/.github/workflows/enforce-license-compliance.yml). 🤖