### PR TITLE
fix(createuser): Use --no-input switch

### DIFF
--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -41,7 +41,7 @@ echo "${_endgroup}"
 echo "${_group}Starting Sentry for tests ..."
 # Disable beacon for e2e tests
 echo 'SENTRY_BEACON=False' >> $SENTRY_CONFIG_PY
-echo y | $dcr web createuser --force-update --superuser --staff --email $TEST_USER --password $TEST_PASS
+$dcr web createuser --no-input --force-update --superuser --email $TEST_USER --password $TEST_PASS
 $dc up -d
 printf "Waiting for Sentry to be up"; timeout 90 bash -c 'until $(curl -Isf -o /dev/null $SENTRY_TEST_HOST); do printf '.'; sleep 0.5; done'
 echo ""

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -41,7 +41,7 @@ echo "${_endgroup}"
 echo "${_group}Starting Sentry for tests ..."
 # Disable beacon for e2e tests
 echo 'SENTRY_BEACON=False' >> $SENTRY_CONFIG_PY
-echo y | $dcr web createuser --force-update --superuser --email $TEST_USER --password $TEST_PASS
+echo y | $dcr web createuser --force-update --superuser --staff --email $TEST_USER --password $TEST_PASS
 $dc up -d
 printf "Waiting for Sentry to be up"; timeout 90 bash -c 'until $(curl -Isf -o /dev/null $SENTRY_TEST_HOST); do printf '.'; sleep 0.5; done'
 echo ""


### PR DESCRIPTION
--staff switch was added to createuser in https://github.com/getsentry/sentry/pull/32802 for usage in Single Tenant, this fixes the test failing after this addition.

Not sure the best approach to manage the chicken & egg problem of requiring this test to pass to merge my PR to sentry master, but merging this check will cause others to fail until I've merged PR.