### PR TITLE
Use better API key when available

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - name: 'Enforce License Compliance'
         uses: getsentry/action-enforce-license-compliance@main
+        with:
+          fossa_api_key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Explanation:

https://github.com/getsentry/action-enforce-license-compliance/blob/236d528c324632485f9e8adb02b515ce01e81d12/action.yml#L16-L26