### PR TITLE
fix: replace git.io links with redirect targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ sudo SENTRY_IMAGE=us.gcr.io/sentryio/sentry:83b1380 ./install.sh
 Where you replace `83b1380` with the sha you want to use.
 
 [build-status-image]: https://github.com/getsentry/self-hosted/workflows/test/badge.svg
-[build-status-url]: https://git.io/JUYkh
+[build-status-url]: https://github.com/getsentry/self-hosted/actions?query=workflow%3Atest+branch%3Amaster+event%3Apush
 

--- a/cron/entrypoint.sh
+++ b/cron/entrypoint.sh
@@ -5,7 +5,7 @@ if [ "$(ls -A /usr/local/share/ca-certificates/)" ]; then
 fi
 
 # Prior art:
-# - https://git.io/fjNOg
+# - https://github.com/renskiy/cron-docker-image/blob/5600db37acf841c6d7a8b4f3866741bada5b4622/debian/start-cron#L34-L36
 # - https://blog.knoldus.com/running-a-cron-job-in-docker-container/
 
 declare -p | grep -Ev 'BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID' > /container.env

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -42,7 +42,7 @@ IS_KVM=$(docker run --rm busybox grep -c 'Common KVM processor' /proc/cpuinfo ||
 if [[ "$IS_KVM" -eq 0 ]]; then
   SUPPORTS_SSE42=$(docker run --rm busybox grep -c sse4_2 /proc/cpuinfo || :)
   if [[ "$SUPPORTS_SSE42" -eq 0 ]]; then
-    echo "FAIL: The CPU your machine is running on does not support the SSE 4.2 instruction set, which is required for one of the services Sentry uses (Clickhouse). See https://git.io/JvLDt for more info."
+    echo "FAIL: The CPU your machine is running on does not support the SSE 4.2 instruction set, which is required for one of the services Sentry uses (Clickhouse). See https://github.com/getsentry/self-hosted/issues/340 for more info."
     exit 1
   fi
 fi

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -4,7 +4,7 @@
 from sentry.conf.server import *  # NOQA
 
 
-# Generously adapted from pynetlinux: https://git.io/JJmga
+# Generously adapted from pynetlinux: https://github.com/rlisagor/pynetlinux/blob/e3f16978855c6649685f0c43d4c3fcf768427ae5/pynetlinux/ifconfig.py#L197-L223
 def get_internal_network():
     import ctypes
     import fcntl
@@ -187,7 +187,7 @@ SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {
     "http": "%s:%s" % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
     "protocol": "uwsgi",
-    # This is needed in order to prevent https://git.io/fj7Lw
+    # This is needed in order to prevent https://github.com/getsentry/sentry/blob/c6f9660e37fcd9c1bbda8ff4af1dcfd0442f5155/src/sentry/services/http.py#L70
     "uwsgi-socket": None,
     "so-keepalive": True,
     # Keep this between 15s-75s as that's what Relay supports


### PR DESCRIPTION
see: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Committed via https://github.com/asottile/all-repos