### PR TITLE
ref: reset user to root for installation

### DIFF
--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
+USER 0
 RUN apt-get update && apt-get install -y --no-install-recommends cron && \
     rm -r /var/lib/apt/lists/*
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
I'm looking to replace `gosu` with a `USER` instruction in https://github.com/getsentry/snuba/pull/2696 -- this requires us to reset the user back to root before proceeding with `apt` installation

