### PR TITLE
fix "services.web.healthcheck.retries must be a number"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-healthcheck-defaults: &healthcheck_defaults
   # https://github.com/getsentry/self-hosted/issues/1000
   interval: "$HEALTHCHECK_INTERVAL"
   timeout: "$HEALTHCHECK_TIMEOUT"
-  retries: "$HEALTHCHECK_RETRIES"
+  retries: $HEALTHCHECK_RETRIES
   start_period: 10s
 x-sentry-defaults: &sentry_defaults
   <<: *restart_policy
@@ -93,7 +93,7 @@ services:
   smtp:
     <<: *restart_policy
     image: tianon/exim4
-    hostname: ${SENTRY_MAIL_HOST:-}
+    hostname: "${SENTRY_MAIL_HOST:-}"
     volumes:
       - "sentry-smtp:/var/spool/exim4"
       - "sentry-smtp-log:/var/log/exim4"


### PR DESCRIPTION
fix https://github.com/getsentry/self-hosted/issues/1343


<!-- Describe your PR here. -->
Seems that docker compose 2.0.0 need types to be defined correctly and do no infer types automatically.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
