### PR TITLE
Bump nginx:1.22.0-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,7 +332,7 @@ services:
     <<: *restart_policy
     ports:
       - "$SENTRY_BIND:80/tcp"
-    image: "nginx:1.21.6-alpine"
+    image: "nginx:1.22.0-alpine"
     volumes:
       - type: bind
         read_only: true


### PR DESCRIPTION
[nginx-1.22.0](https://nginx.org/en/download.html) stable version has been released, incorporating new features and bug fixes from the 1.21.x mainline branch  — including hardening against potential requests smuggling and cross-protocol attacks, [ALPN support](https://nginx.org/en/docs/stream/ngx_stream_ssl_module.html#ssl_alpn) in the stream module, better distribution of connections among worker processes on Linux, support for the PCRE2 library, support for OpenSSL 3.0 and SSL_sendfile(), improved [sendfile](https://nginx.org/en/docs/http/ngx_http_core_module.html#sendfile) handling on FreeBSD, the[ mp4_start_key_frame](https://nginx.org/en/docs/http/ngx_http_mp4_module.html#mp4_start_key_frame) directive, and more.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
