### PR TITLE
snuba: New subscriptions infrastucture rollout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -250,10 +250,10 @@ services:
     command: replacer --storage errors --auto-offset-reset=latest --max-batch-size 3
   snuba-subscription-consumer-events:
     <<: *snuba_defaults
-    command: subscriptions --auto-offset-reset=latest --consumer-group=snuba-events-subscriptions-consumers --topic=events --result-topic=events-subscription-results --dataset=events --commit-log-topic=snuba-commit-log --commit-log-group=snuba-consumers --delay-seconds=60 --schedule-ttl=60
+    command: subscriptions-scheduler-executor --dataset events --entity events --auto-offset-reset=latest --no-strict-offset-reset --consumer-group=snuba-events-subscriptions-consumers --followed-consumer-group=snuba-consumers --delay-seconds=60 --schedule-ttl=60 --stale-threshold-seconds=900
   snuba-subscription-consumer-transactions:
     <<: *snuba_defaults
-    command: subscriptions --auto-offset-reset=latest --consumer-group=snuba-transactions-subscriptions-consumers --topic=events --result-topic=transactions-subscription-results --dataset=transactions --commit-log-topic=snuba-commit-log --commit-log-group=transactions_group --delay-seconds=60 --schedule-ttl=60
+    command: subscriptions-scheduler-executor --dataset transactions --entity transactions --auto-offset-reset=latest --no-strict-offset-reset --consumer-group=snuba-transactions-subscriptions-consumers --followed-consumer-group=transactions_group --delay-seconds=60 --schedule-ttl=60 --stale-threshold-seconds=900
   snuba-cleanup:
     <<: *snuba_defaults
     image: snuba-cleanup-self-hosted-local
@@ -297,7 +297,7 @@ services:
       test:
         - "CMD"
         - "/bin/bash"
-        - '-c'
+        - "-c"
         # Courtesy of https://unix.stackexchange.com/a/234089/108960
         - 'exec 3<>/dev/tcp/127.0.0.1/9000 && echo -e "GET /_health/ HTTP/1.1\r\nhost: 127.0.0.1\r\n\r\n" >&3 && grep ok -s -m 1 <&3'
   cron:


### PR DESCRIPTION
We have rebuilt the Snuba subscriptions infrastructure to help with scaling
subscriptions in SaaS. Hopefully it will be a bit more stable for self hosted
as well. It's configured to be able to recover more quickly from any downtimes or
backlogs as it ignores stale subscriptions and only executes and delivers alerts
on recent ones.

The ability to run the old subscriptions process will be removed in an upcoming
Snuba release.