### PR TITLE
Add volume for nginx cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,6 +338,7 @@ services:
         read_only: true
         source: ./nginx
         target: /etc/nginx
+      - sentry-nginx-cache:/var/cache/nginx
     depends_on:
       - web
       - relay
@@ -380,6 +381,7 @@ volumes:
   # These store ephemeral data that needn't persist across restarts.
   sentry-secrets:
   sentry-smtp:
+  sentry-nginx-cache:
   sentry-zookeeper-log:
   sentry-kafka-log:
   sentry-smtp-log:


### PR DESCRIPTION
Use volume for writable data, as it's supposedly faster because no need to update overlayfs layers on volumes.

NOTE: `nginx` itself does `chown nginx` on startup according to my tests:

```
# docker-compose exec nginx ls -la /var/cache/nginx
total 0
drwxr-xr-x    1 root     root            98 Jun 12 17:05 .
drwxr-xr-x    1 root     root            19 Nov 13  2021 ..
drwxr-xr-x    2 nginx    root             6 Jun 12 17:05 client_temp
drwx------    2 nginx    root             6 Jun 12 17:05 fastcgi_temp
drwx------    2 nginx    root             6 Jun 12 17:05 proxy_temp
drwx------    2 nginx    root             6 Jun 12 17:05 scgi_temp
drwx------    2 nginx    root             6 Jun 12 17:05 uwsgi_temp
```

Refs:
- https://github.com/getsentry/self-hosted/issues/1381#issuecomment-1068061553

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
