### PR TITLE
Run release a new version job only on getsentry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
     - cron: "0 18 15 * *"
 jobs:
   release:
+    if: github.repository_owner == 'getsentry'
     runs-on: ubuntu-latest
     name: "Release a new version"
     steps:


### PR DESCRIPTION
In order to prevent a failed job run on forked repositories :)

For example:
https://github.com/aminvakil/self-hosted/runs/6905699181?check_suite_focus=true

It fails instantly right now with `Error: Input required and not supplied: token`, but why it should be run on forked repositories anyway?

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
