### PR TITLE
ref: Replace regex with --short flag to get compose version

### DIFF
--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -12,8 +12,7 @@ if [[ "$(ver $DOCKER_VERSION)" -lt "$(ver $MIN_DOCKER_VERSION)" ]]; then
 fi
 echo "Found Docker version $DOCKER_VERSION"
 
-# See https://github.com/getsentry/self-hosted/issues/1132#issuecomment-982823712 ff. for regex testing.
-COMPOSE_VERSION=$($dc_base version | head -n1 | sed -E 's/^.* version:? v?([0-9.]+),?.*$/\1/')
+COMPOSE_VERSION=$($dc_base version --short)
 if [[ "$(ver $COMPOSE_VERSION)" -lt "$(ver $MIN_COMPOSE_VERSION)" ]]; then
   echo "FAIL: Expected minimum $dc_base version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
   exit 1


### PR DESCRIPTION
While looking at how we get the compose version for https://github.com/getsentry/self-hosted/issues/1550 I realized there was a cleaner way to do this. This flag works all the way back to compose 1.4, when the `version` argument was introduced.