### PR TITLE
Add check requiring git checkout

### DIFF
--- a/install/check-latest-commit.sh
+++ b/install/check-latest-commit.sh
@@ -9,7 +9,9 @@ if [[ -d "../.git" && "${SKIP_COMMIT_CHECK:-0}" != 1 ]]; then
     fi
   fi
 else
-  echo "skipped"
+  # Require a git checkout to avoid permissions issues ref https://github.com/getsentry/self-hosted/issues/1532
+  echo "Detected sources not from git checkout. Please clone the repository instead of downloading a ZIP."
+  exit 1
 fi
 
 echo "${_endgroup}"


### PR DESCRIPTION
This adds a requirement that the install script is run from a git checkout, not from a zip. This is to avoid issues like https://github.com/getsentry/self-hosted/issues/1532