### PR TITLE
Use docker-compose 2.7.0 instead of 2.2.3 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           #   compose_path: "/usr/local/bin"
           - compose_version: "v2.0.1"
             compose_path: "/usr/local/lib/docker/cli-plugins"
-          - compose_version: "v2.2.3"
+          - compose_version: "v2.9.0"
             compose_path: "/usr/local/lib/docker/cli-plugins"
     env:
       COMPOSE_PROJECT_NAME: self-hosted-${{ strategy.job-index }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           #   compose_path: "/usr/local/bin"
           - compose_version: "v2.0.1"
             compose_path: "/usr/local/lib/docker/cli-plugins"
-          - compose_version: "v2.9.0"
+          - compose_version: "v2.8.0"
             compose_path: "/usr/local/lib/docker/cli-plugins"
     env:
       COMPOSE_PROJECT_NAME: self-hosted-${{ strategy.job-index }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           #   compose_path: "/usr/local/bin"
           - compose_version: "v2.0.1"
             compose_path: "/usr/local/lib/docker/cli-plugins"
-          - compose_version: "v2.9.0"
+          - compose_version: "v2.7.0"
             compose_path: "/usr/local/lib/docker/cli-plugins"
     env:
       COMPOSE_PROJECT_NAME: self-hosted-${{ strategy.job-index }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           #   compose_path: "/usr/local/bin"
           - compose_version: "v2.0.1"
             compose_path: "/usr/local/lib/docker/cli-plugins"
-          - compose_version: "v2.8.0"
+          - compose_version: "v2.9.0"
             compose_path: "/usr/local/lib/docker/cli-plugins"
     env:
       COMPOSE_PROJECT_NAME: self-hosted-${{ strategy.job-index }}


### PR DESCRIPTION
Then I'm going to implement https://github.com/getsentry/self-hosted/issues/1294#issuecomment-1180281521, but first this needs to be merged.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
