### PR TITLE
Add --no-recreate to dc up in wrap-up.sh only for docker-compose 2.2.4 and more

### DIFF
--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -10,6 +10,7 @@ else
   $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
   $dc restart relay
   $dc exec -T nginx nginx -s reload
+fi
 
   docker run --rm --network="${COMPOSE_PROJECT_NAME}_default" alpine ash \
     -c 'while [[ "$(wget -T 1 -q -O- http://web:9000/_health/)" != "ok" ]]; do sleep 0.5; done'

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -2,7 +2,7 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
   echo "${_group}Waiting for Sentry to start ..."
 
   # Start the whole setup, except nginx and relay.
-  $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
+  $dc up --no-recreate -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
   $dc restart relay
   $dc exec -T nginx nginx -s reload
 

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -5,7 +5,7 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
 if [[ "$(vergte ${COMPOSE_VERSION//v} '2.2.4')" ]]; then
   $dc up --no-recreate -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
   echo "As you're using docker-compose >= 2.2.4 we have added --no-recreate to your docker compose up command."
-  echo "If you're facing any problem, please report to https://github.com/getsentry/self-hosted/issues/1294"
+  echo "If you're facing any problems, please report to https://github.com/getsentry/self-hosted/issues/1294"
 else
   $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
   $dc restart relay

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -2,7 +2,12 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
   echo "${_group}Waiting for Sentry to start ..."
 
   # Start the whole setup, except nginx and relay.
+if [[ "$(vergte ${COMPOSE_VERSION//v} '2.2.4')" ]]; then
   $dc up --no-recreate -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
+  echo "As you're using docker-compose >= 2.2.4 we have added --no-recreate to your docker compose up command."
+  echo "If you're facing any problem, please report to https://github.com/getsentry/self-hosted/issues/1294"
+else
+  $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
   $dc restart relay
   $dc exec -T nginx nginx -s reload
 


### PR DESCRIPTION
Fixes #1294 

Original PR: https://github.com/getsentry/self-hosted/pull/1393

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
