### PR TITLE
Fix fresh install of self-hosted for ARM by removing the --platform parameter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ x-healthcheck-defaults: &healthcheck_defaults
 x-sentry-defaults: &sentry_defaults
   <<: *restart_policy
   image: sentry-self-hosted-local
-  # Set the platform to build for linux/arm64 when needed on Apple silicon Macs.
-  platform: ${DOCKER_PLATFORM:-}
   build:
     context: ./sentry
     args:


### PR DESCRIPTION
Fresh install of self-hosted was throwing an exception here on my M1 macbook pro:

```console
▶ Setting up / migrating database …
...
Container sentry-self-hosted-clickhouse-1  Healthy
Container sentry-self-hosted-kafka-1  Healthy
Container sentry-self-hosted-kafka-1  Healthy
Container sentry-self-hosted-kafka-1  Healthy
Container sentry-self-hosted-redis-1  Healthy
Container sentry-self-hosted-clickhouse-1  Healthy
Container sentry-self-hosted-clickhouse-1  Healthy
Container sentry-self-hosted-clickhouse-1  Healthy
Container sentry-self-hosted-snuba-sessions-consumer-1  Starting
Container sentry-self-hosted-snuba-subscription-consumer-events-1  Starting
Container sentry-self-hosted-snuba-outcomes-consumer-1  Starting
Container sentry-self-hosted-snuba-transactions-consumer-1  Starting
Container sentry-self-hosted-snuba-api-1  Starting
Container sentry-self-hosted-snuba-consumer-1  Starting
Container sentry-self-hosted-snuba-subscription-consumer-transactions-1  Starting
Container sentry-self-hosted-snuba-replacer-1  Starting
Container sentry-self-hosted-snuba-outcomes-consumer-1  Started
Container sentry-self-hosted-snuba-api-1  Started
Container sentry-self-hosted-snuba-subscription-consumer-events-1  Started
Container sentry-self-hosted-snuba-transactions-consumer-1  Started
Container sentry-self-hosted-snuba-subscription-consumer-transactions-1  Started
Container sentry-self-hosted-snuba-sessions-consumer-1  Started
Container sentry-self-hosted-snuba-replacer-1  Started
Container sentry-self-hosted-snuba-consumer-1  Started
Error response from daemon: image with reference sentry-self-hosted-local was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64
```

This is happening in the installation process because certain images are only available for `linux/amd64` and the `platform` parameter here forces us to look for a `linux/arm64` image, eventually erroring out. For M1 macs, I don't think we can confidently assume the platform to be `linux/arm64` as long as we are running `linux/amd64` single arch images. For multi-arch images, docker should automatically pull in the image that matches the current OS and architecture.

Github thread here for more context on a similar scenario:
https://github.com/docker/for-linux/issues/1170#issuecomment-784209110

Docker multi-arch support:
https://docs.docker.com/desktop/multi-arch/

Follow up on 
https://github.com/getsentry/self-hosted/pull/1538