### PR TITLE
added docker commands in the description

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -13,16 +13,20 @@ body:
     id: cpu_architecture
     attributes:
       label: CPU Architecture
-      placeholder: x86_64 ← should look like this (docker info --format '{{.Architecture}}')
-      description: What cpu architecture are you running self-hosted on?
+      placeholder: x86_64 ← should look like this
+      description: |
+        What cpu architecture are you running self-hosted on?
+        e.g: (docker info --format '{{.Architecture}}')
     validations:
       required: true
   - type: input
     id: docker_version
     attributes:
       label: Docker Version
-      placeholder: 20.10.16 ← should look like this (docker --version)
-      description: What version of docker are you using to run self-hosted?
+      placeholder: 20.10.16 ← should look like this 
+      description: |
+        What version of docker are you using to run self-hosted?
+        e.g: (docker --version)
     validations:
       required: true
   - type: input
@@ -56,11 +60,14 @@ body:
     id: actual
     attributes:
       label: Actual Result
-      description: Logs? Screenshots? Yes, please.
+      description: |
+        Logs? Screenshots? Yes, please.
+        e.g.:
+          - latest install logs: `ls -1 sentry_install_log-*.txt | tail -1 | xargs cat`
+          - `docker compose logs` output
       placeholder: |-
         e.g.:
-        - latest install logs: `ls -1 sentry_install_log-*.txt | tail -1 | xargs cat`
-        - `docker compose logs` output
+        - logs output
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
<!-- Describe your PR here. -->

make it easier for the user to copy the docker commands, when they are in the placeholder you cannot easily copy them (only by source code or by seeing the template)

Thanks

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
