### PR TITLE
fix(e2e tests): Add .reporterrors file for GCP run of e2e tests

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,6 +7,7 @@ steps:
       - "-c"
       - |
         git clone https://github.com/getsentry/self-hosted.git
+        echo 'no' > .reporterrors
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > self-hosted/docker-compose.override.yml
     timeout: 60s
   - name: "gcr.io/$PROJECT_ID/docker-compose"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
       - "-c"
       - |
         git clone https://github.com/getsentry/self-hosted.git
-        echo 'no' > .reporterrors
+        echo 'no' > self-hosted/.reporterrors
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > self-hosted/docker-compose.override.yml
     timeout: 60s
   - name: "gcr.io/$PROJECT_ID/docker-compose"


### PR DESCRIPTION
Add .reporterrors file with "no" for GCP run of e2e tests, required for dogfood change to skip user prompt