### PR TITLE
fix(e2e tests): Pull branch that initially triggers gcp build for PRs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - "-e"
       - "-c"
       - |
-        git clone https://github.com/getsentry/self-hosted.git
+        git clone -b $BRANCH_NAME https://github.com/getsentry/self-hosted.git
         echo 'no' > self-hosted/.reporterrors
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > self-hosted/docker-compose.override.yml
     timeout: 60s


### PR DESCRIPTION
For our PR check in self-hosted, we must checkout the branch of the PR.
https://console.cloud.google.com/cloud-build/triggers;region=global/edit/136f08d0-ed33-43a6-a009-55aed7a84bb3?project=sentryio

The `$BRANCH_NAME` is an env variable provided by GCP.

https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
