### PR TITLE
Default to not sending data to Sentry for now

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,6 @@ steps:
       - "-c"
       - |
         git clone -b $BRANCH_NAME https://github.com/getsentry/self-hosted.git
-        echo 'no' > self-hosted/.reporterrors
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > self-hosted/docker-compose.override.yml
     timeout: 60s
   - name: "gcr.io/$PROJECT_ID/docker-compose"

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -8,6 +8,13 @@ umask 002
 log_file="sentry_install_log-`date +'%Y-%m-%d_%H-%M-%S'`.txt"
 exec &> >(tee -a "$log_file")
 
+# Thanks to https://tldp.org/LDP/abs/html/intandnonint.html
+if [[ "$(tty)" == "not a tty" ]]; then
+  PROMPTABLE=0
+else
+  PROMPTABLE=1
+fi
+
 # Work from /install/ for install.sh, project root otherwise
 if [[ "$(basename $0)" = "install.sh"  ]]; then
   cd "$(dirname $0)/install/"

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -43,9 +43,10 @@ else
     echo
     echo "Thirty (30) day retention. No marketing. Privacy policy at sentry.io/privacy."
     echo
-    echo "For now we are defaulting to opt-out, but our plan is to hard-require a choice"
-    echo "from you starting in version 22.12.0, because let's be honest, none of you will"
-    echo "act on this otherwise. To avoid disruption you can:"
+    echo "For now we are defaulting to not sending data, but our plan is to hard-require"
+    echo "a choice from you starting in version 22.10.0, because let's be honest, none of"
+    echo "you will act on this otherwise. To avoid disruption you can use one of these"
+    echo "flags:"
     echo
     echo "  echo no > /path/to/sentry/.reporterrors"
     echo

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -22,42 +22,77 @@ if [[ -f $reporterrors ]]; then
     export REPORT_ERRORS=0
   fi
 else
-  echo
-  echo "Hey, so ... we would love to find out when you hit an issue with this here"
-  echo "installer you are running. Turns out there is an app for that, called Sentry."
-  echo "Are you okay with us sending info to Sentry when you run this installer?"
-  echo
-  echo "  y / yes / 1"
-  echo "  n / no / 0"
-  echo
-  echo "(Btw, we send this to our own self-hosted Sentry instance, not to Sentry SaaS,"
-  echo "so that we can be in this together.)"
-  echo
-  echo "Here's the info we may collect in order to help us improve the installer:"
-  echo
-  echo "  - OS username"
-  echo "  - IP address"
-  echo "  - install log"
-  echo "  - performance data"
-  echo
-  echo "Thirty (30) day retention. No marketing. Privacy policy at sentry.io/privacy."
-  echo
+  if [[ $PROMPTABLE == "0" ]]; then
+    echo
+    echo "Hey, so ... we would love to find out when you hit an issue with this here"
+    echo "installer you are running. Turns out there is an app for that, called Sentry."
+    echo "Would you be willing to let us automatically send data to Sentry from this "
+    echo "installer? If so, add this to your automation:"
+    echo
+    echo "  echo yes > /path/to/sentry/.reporterrors"
+    echo
+    echo "(Btw, we send this to our own self-hosted Sentry instance, not to Sentry SaaS,"
+    echo "so that we can be in this together.)"
+    echo
+    echo "Here's the info we may collect in order to help us improve the installer:"
+    echo
+    echo "  - OS username"
+    echo "  - IP address"
+    echo "  - install log"
+    echo "  - performance data"
+    echo
+    echo "Thirty (30) day retention. No marketing. Privacy policy at sentry.io/privacy."
+    echo
+    echo "For now we are defaulting to opt-out, but our plan is to hard-require a choice"
+    echo "from you starting in version 22.12.0, because let's be honest, none of you will"
+    echo "act on this otherwise. To avoid disruption you can:"
+    echo
+    echo "  echo no > /path/to/sentry/.reporterrors"
+    echo
+    echo "We'll probably also add an env var and/or CLI flag before then, too. See:"
+    echo
+    echo "  https://github.com/getsentry/team-ospo/issues/36"
+    echo
+    echo "Thanks for using Sentry."
+    echo
+  else
+    echo
+    echo "Hey, so ... we would love to find out when you hit an issue with this here"
+    echo "installer you are running. Turns out there is an app for that, called Sentry."
+    echo "Are you okay with us sending info to Sentry when you run this installer?"
+    echo
+    echo "  y / yes / 1"
+    echo "  n / no / 0"
+    echo
+    echo "(Btw, we send this to our own self-hosted Sentry instance, not to Sentry SaaS,"
+    echo "so that we can be in this together.)"
+    echo
+    echo "Here's the info we may collect in order to help us improve the installer:"
+    echo
+    echo "  - OS username"
+    echo "  - IP address"
+    echo "  - install log"
+    echo "  - performance data"
+    echo
+    echo "Thirty (30) day retention. No marketing. Privacy policy at sentry.io/privacy."
+    echo
 
-  yn=""
-  until [ ! -z "$yn" ]
-  do
-    read -p "y or n? " yn
-    case $yn in
-      y | yes | 1) export REPORT_ERRORS=1; echo "yes" > $reporterrors; echo; echo -n "Thank you.";;
-      n | no | 0) export REPORT_ERRORS=0; echo "no" > $reporterrors; echo; echo -n "Understood.";;
-      *) yn="";;
-    esac
-  done
+    yn=""
+    until [ ! -z "$yn" ]
+    do
+      read -p "y or n? " yn
+      case $yn in
+        y | yes | 1) export REPORT_ERRORS=1; echo "yes" > $reporterrors; echo; echo -n "Thank you.";;
+        n | no | 0) export REPORT_ERRORS=0; echo "no" > $reporterrors; echo; echo -n "Understood.";;
+        *) yn="";;
+      esac
+    done
 
-  echo " Your answer is cached in '.reporterrors', remove it to see this"
-  echo "prompt again."
-  echo
-  sleep 5
+    echo " Your answer is cached in '.reporterrors', remove it to see this"
+    echo "prompt again."
+    echo
+    sleep 5
+  fi
 fi
 
 # Make sure we can use sentry-cli if we need it.

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -4,7 +4,6 @@ set -ex
 echo "Reset customizations"
 rm -f sentry/enhance-image.sh
 rm -f sentry/requirements.txt
-echo no > .reporterrors
 
 echo "Testing initial install"
 ./install.sh


### PR DESCRIPTION
Follow-up to #1679 to relax the non-interactive experience, closes #1693.

The proposal here is to default to not sending data for the non-interactive case, but with a notice that we will be forcing a decision in an upcoming version. This gives folks three months to notice and adjust, and it gives us some time to clean up configuration a bit.