### PR TITLE
Rename flag to --skip-user-creation

### DIFF
--- a/install/parse-cli.sh
+++ b/install/parse-cli.sh
@@ -16,20 +16,32 @@ Options:
                           upgrades.
  --skip-commit-check    Skip the check for the latest commit when on the master
                           branch of a \`self-hosted\` Git working copy.
- --skip-user-prompt     Skip the initial user creation prompt (ideal for non-
+ --skip-user-creation   Skip the initial user creation prompt (ideal for non-
                           interactive installs).
 EOF
 }
 
-SKIP_USER_PROMPT="${SKIP_USER_PROMPT:-}"
+depwarn() {
+  echo "WARNING The $1 is deprecated. Please use $2 instead."
+}
+
+if [ ! -z "${SKIP_USER_PROMPT:-}" ]; then
+  depwarn "SKIP_USER_PROMPT variable" "SKIP_USER_CREATION"
+  SKIP_USER_CREATION="${SKIP_USER_PROMPT}"
+fi
+
+SKIP_USER_CREATION="${SKIP_USER_CREATION:-}"
 MINIMIZE_DOWNTIME="${MINIMIZE_DOWNTIME:-}"
 SKIP_COMMIT_CHECK="${SKIP_COMMIT_CHECK:-}"
 
 while (( $# )); do
   case "$1" in
     -h | --help) show_help; exit;;
-    --no-user-prompt) SKIP_USER_PROMPT=1;;  # deprecated
-    --skip-user-prompt) SKIP_USER_PROMPT=1;;
+    --no-user-prompt) SKIP_USER_CREATION=1;
+      depwarn "--no-user-prompt flag" "--skip-user-creation";;
+    --skip-user-prompt) SKIP_USER_CREATION=1;
+      depwarn "--skip-user-prompt flag" "--skip-user-creation";;
+    --skip-user-creation) SKIP_USER_CREATION=1;;
     --minimize-downtime) MINIMIZE_DOWNTIME=1;;
     --skip-commit-check) SKIP_COMMIT_CHECK=1;;
     --) ;;

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -3,8 +3,8 @@ echo "${_group}Setting up / migrating database ..."
 if [[ -n "${CI:-}" || "${SKIP_USER_CREATION:-0}" == 1 ]]; then
   $dcr web upgrade --noinput
   echo ""
-  echo "Did not prompt for user creation due to non-interactive shell."
-  echo "Run the following command to create one yourself (recommended):"
+  echo "Did not prompt for user creation. Run the following command to create one"
+  echo "yourself (recommended):"
   echo ""
   echo "  $dc_base run --rm web createuser"
   echo ""

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -1,6 +1,6 @@
 echo "${_group}Setting up / migrating database ..."
 
-if [[ -n "${CI:-}" || "${SKIP_USER_PROMPT:-0}" == 1 ]]; then
+if [[ -n "${CI:-}" || "${SKIP_USER_CREATION:-0}" == 1 ]]; then
   $dcr web upgrade --noinput
   echo ""
   echo "Did not prompt for user creation due to non-interactive shell."


### PR DESCRIPTION
The "user' in `--skip-user-prompt` is ambiguous. It's [intended](https://github.com/getsentry/self-hosted/blob/31767d27957cbba5281469df740379edd28df121/install/parse-cli.sh#L19) to refer to the initial Sentry user, but it's natural to think (as we saw at https://github.com/getsentry/self-hosted/issues/1693#issuecomment-1246604464) that it refers to the person operating Sentry, so that it would suppress _all_ interactive prompts during the installer.

```
$ SKIP_USER_PROMPT=1 ./install.sh --no-user-prompt --skip-user-prompt
▶ Parsing command line ...
WARNING The SKIP_USER_PROMPT variable is deprecated. Please use SKIP_USER_CREATION instead.
WARNING The --no-user-prompt flag is deprecated. Please use --skip-user-creation instead.
WARNING The --skip-user-prompt flag is deprecated. Please use --skip-user-creation instead.

▶ Detecting Docker platform

```