### PR TITLE
Fix traceback hash for error monitoring

### DIFF
--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -148,7 +148,7 @@ cleanup () {
     echo "$traceback"
 
     if [ "$REPORT_SELF_HOSTED_ISSUES" == 1 ]; then
-      local traceback_hash=$(echo -n $traceback | docker run --rm busybox md5sum | cut -d' ' -f1)
+      local traceback_hash=$(echo -n $traceback | docker run -i --rm busybox md5sum | cut -d' ' -f1)
       send_event "$traceback_hash" "$cmd_exit"
     fi
 


### PR DESCRIPTION
add `-i` flag to keep STDIN open even if not attached
We were hashing an empty string before 😬