### PR TITLE
Tag releases with sentry-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,17 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           calver: true
+      - name: Create new release in Self-hosted Sentry
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          # Create new Sentry release
+          export SENTRY_DSN='https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
+          export SENTRY_ORG=self-hosted
+          export SENTRY_PROJECT=installer
+          export SENTRY_RELEASE=$(sentry-cli releases propose-version)
+          sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
+          sentry-cli releases set-commits --auto $SENTRY_RELEASE
+          sentry-cli releases finalize $SENTRY_RELEASE
+
+          # Create new deploy for this Sentry release
+          sentry-cli releases deploys $SENTRY_RELEASE new -e production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,17 +33,16 @@ jobs:
       #     calver: true
       - name: Create new release in Self-hosted Sentry
         env:
-          SENTRY_LOG_LEVEL: debug
           SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
           SENTRY_ORG: self-hosted
           SENTRY_PROJECT: installer
           SENTRY_URL: https://self-hosted.getsentry.net/
           SENTRY_AUTH_TOKEN: ${{ secrets.SELF_HOSTED_RELEASE_TOKEN }}
+          SENTRY_RELEASE: ${{ github.event.inputs.version }}
         run: |
           curl -sL https://sentry.io/get-cli/ | bash
 
           # Create new Sentry release
-          export SENTRY_RELEASE=$(sentry-cli releases propose-version)
           sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
           sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases set-commits --auto $SENTRY_RELEASE
           sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases finalize $SENTRY_RELEASE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
-      # - name: Prepare release
-      #   uses: getsentry/action-prepare-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
-      #   with:
-      #     version: ${{ github.event.inputs.version }}
-      #     force: ${{ github.event.inputs.force }}
-      #     calver: true
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+          calver: true
       - name: Create new release in Self-hosted Sentry
         env:
           SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           curl -sL https://sentry.io/get-cli/ | bash
           # Create new Sentry release
+          export SENTRY_LOG_LEVEL=debug
           export SENTRY_DSN='https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
           export SENTRY_ORG=self-hosted
           export SENTRY_PROJECT=installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
           SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
           SENTRY_ORG: self-hosted
           SENTRY_PROJECT: installer
+          SENTRY_URL: https://self-hosted.getsentry.net/
           SENTRY_AUTH_TOKEN: ${{ secrets.SELF_HOSTED_RELEASE_TOKEN }}
         run: |
           curl -sL https://sentry.io/get-cli/ | bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,20 @@ jobs:
       #     force: ${{ github.event.inputs.force }}
       #     calver: true
       - name: Create new release in Self-hosted Sentry
+        env:
+          SENTRY_LOG_LEVEL: debug
+          SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
+          SENTRY_ORG: self-hosted
+          SENTRY_PROJECT: installer
+          SENTRY_AUTH_TOKEN: ${{ secrets.SELF_HOSTED_RELEASE_TOKEN }}
         run: |
           curl -sL https://sentry.io/get-cli/ | bash
+
           # Create new Sentry release
-          export SENTRY_LOG_LEVEL=debug
-          export SENTRY_DSN='https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
-          export SENTRY_ORG=self-hosted
-          export SENTRY_PROJECT=installer
           export SENTRY_RELEASE=$(sentry-cli releases propose-version)
-          sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-          sentry-cli releases set-commits --auto $SENTRY_RELEASE
-          sentry-cli releases finalize $SENTRY_RELEASE
+          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
+          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases set-commits --auto $SENTRY_RELEASE
+          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases finalize $SENTRY_RELEASE
 
           # Create new deploy for this Sentry release
-          sentry-cli releases deploys $SENTRY_RELEASE new -e production
+          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases deploys $SENTRY_RELEASE new -e production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
-      - name: Prepare release
-        uses: getsentry/action-prepare-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
-        with:
-          version: ${{ github.event.inputs.version }}
-          force: ${{ github.event.inputs.force }}
-          calver: true
+      # - name: Prepare release
+      #   uses: getsentry/action-prepare-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+      #   with:
+      #     version: ${{ github.event.inputs.version }}
+      #     force: ${{ github.event.inputs.force }}
+      #     calver: true
       - name: Create new release in Self-hosted Sentry
         run: |
           curl -sL https://sentry.io/get-cli/ | bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           calver: true
-      - name: Create new release in Self-hosted Sentry
+      - name: Create new release in self-hosted Sentry
         env:
           SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
           SENTRY_ORG: self-hosted


### PR DESCRIPTION
uses sentry-cli to tag releases for us on our self-hosted instance