### PR TITLE
Request event ID in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -70,6 +70,13 @@ body:
         - logs output
     validations:
       required: true
+  - type: textarea
+    id: event_id
+    attributes:
+      label: Event ID
+      description: |
+        If you opted into sending errors to our error monitoring and the error has an event ID, enter it here!
+      placeholder: c2d85058-d3b0-4d85-a509-e2ba965845d7 
   - type: markdown
     attributes:
       value: |-


### PR DESCRIPTION
This was based on a suggestion by @aminvakil to make it easier to link issues on Github and Sentry.
