### PR TITLE
Fix minimum version requirements for docker and docker compose

### DIFF
--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -13,14 +13,14 @@ if [[ -z "$DOCKER_VERSION" ]]; then
   exit 1
 fi
 
-if [[ "$(vergte ${DOCKER_VERSION//v} $MIN_DOCKER_VERSION)" ]]; then
+if [[ ! "$(vergte ${DOCKER_VERSION//v} $MIN_DOCKER_VERSION)" ]]; then
   echo "FAIL: Expected minimum docker version to be $MIN_DOCKER_VERSION but found $DOCKER_VERSION"
   exit 1
 fi
 echo "Found Docker version $DOCKER_VERSION"
 
 COMPOSE_VERSION=$($dc_base version --short)
-if [[ "$(vergte ${COMPOSE_VERSION//v} $MIN_COMPOSE_VERSION)" ]]; then
+if [[ ! "$(vergte ${COMPOSE_VERSION//v} $MIN_COMPOSE_VERSION)" ]]; then
   echo "FAIL: Expected minimum $dc_base version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
   exit 1
 fi

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -13,14 +13,14 @@ if [[ -z "$DOCKER_VERSION" ]]; then
   exit 1
 fi
 
-if [[ ! "$(vergte ${DOCKER_VERSION//v} $MIN_DOCKER_VERSION)" ]]; then
+if [[ "$(vergte ${DOCKER_VERSION//v} $MIN_DOCKER_VERSION)" -eq 1 ]]; then
   echo "FAIL: Expected minimum docker version to be $MIN_DOCKER_VERSION but found $DOCKER_VERSION"
   exit 1
 fi
 echo "Found Docker version $DOCKER_VERSION"
 
 COMPOSE_VERSION=$($dc_base version --short)
-if [[ ! "$(vergte ${COMPOSE_VERSION//v} $MIN_COMPOSE_VERSION)" ]]; then
+if [[ "$(vergte ${COMPOSE_VERSION//v} $MIN_COMPOSE_VERSION)" -eq 1 ]]; then
   echo "FAIL: Expected minimum $dc_base version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
   exit 1
 fi

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -3,7 +3,7 @@ echo "${_group}Checking minimum requirements ..."
 source "$(dirname $0)/_min-requirements.sh"
 
 # Check the version of $1 is greater than or equal to $2 using sort. Note: versions must be stripped of "v"
-function vergte () { printf "%s\n%s" $1 $2 | sort --version-sort --check=quiet --reverse; }
+function vergte () { printf "%s\n%s" $1 $2 | sort --version-sort --check=quiet --reverse; echo $?; }
 
 
 


### PR DESCRIPTION
The function vergte here doesn't correctly use the return code in order to be used in version comparison. As a result, users are running older versions of docker compose. The issue with the largest number of events in our dogfood instance seems to be a result of folks using an older version of docker compose, then erroring out later during the turn things off script.

This fixes the issue here:
https://github.com/getsentry/self-hosted/issues/1706