### PR TITLE
Check to see if docker compose exists, else error out

### DIFF
--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -25,7 +25,7 @@ if [[ -z "$COMPOSE_VERSION" ]]; then
   exit 1
 fi
 
-if [[ "$(vergte ${COMPOSE_VERSION//v} $MIN_COMPOSE_VERSION)" ]]; then
+if [[ "$(vergte ${COMPOSE_VERSION//v} $MIN_COMPOSE_VERSION)" -eq 1 ]]; then
   echo "FAIL: Expected minimum $dc_base version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
   exit 1
 fi

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -19,7 +19,13 @@ if [[ "$(vergte ${DOCKER_VERSION//v} $MIN_DOCKER_VERSION)" ]]; then
 fi
 echo "Found Docker version $DOCKER_VERSION"
 
-COMPOSE_VERSION=$($dc_base version --short)
+if [[ $($dc_base version --short) ]]; then
+  COMPOSE_VERSION=$($dc_base version --short)
+else
+  echo "FAIL: Docker compose is required to run self-hosted"
+  exit 1
+fi
+
 if [[ "$(vergte ${COMPOSE_VERSION//v} $MIN_COMPOSE_VERSION)" ]]; then
   echo "FAIL: Expected minimum $dc_base version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
   exit 1

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -7,8 +7,9 @@ function vergte () { printf "%s\n%s" $1 $2 | sort --version-sort --check=quiet -
 
 
 
-DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
-if [[ -z "$DOCKER_VERSION" ]]; then
+if [[ $(docker version --format '{{.Server.Version}}') ]]; then
+  DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
+else
   echo "FAIL: Unable to get docker version, is the docker daemon running?"
   exit 1
 fi

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -7,9 +7,8 @@ function vergte () { printf "%s\n%s" $1 $2 | sort --version-sort --check=quiet -
 
 
 
-if [[ $(docker version --format '{{.Server.Version}}') ]]; then
-  DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
-else
+DOCKER_VERSION=$(docker version --format '{{.Server.Version}}' || echo '')
+if [[ -z "$DOCKER_VERSION" ]]; then
   echo "FAIL: Unable to get docker version, is the docker daemon running?"
   exit 1
 fi
@@ -20,9 +19,8 @@ if [[ "$(vergte ${DOCKER_VERSION//v} $MIN_DOCKER_VERSION)" ]]; then
 fi
 echo "Found Docker version $DOCKER_VERSION"
 
-if [[ $($dc_base version --short) ]]; then
-  COMPOSE_VERSION=$($dc_base version --short)
-else
+COMPOSE_VERSION=$($dc_base version --short || echo '')
+if [[ -z "$COMPOSE_VERSION" ]]; then
   echo "FAIL: Docker compose is required to run self-hosted"
   exit 1
 fi


### PR DESCRIPTION
One of our most common errors that we're seeing on self-hosted occurs when docker-compose doesn't exist. Our version check then throws an exception.

https://self-hosted.getsentry.net/organizations/self-hosted/issues/16/?query=is%3Aunresolved

This PR adds logic to ensure that we're able to find the version of docker compose and output an error msg to the user when docker compose does not exist. 