### PR TITLE
Fix sentry release for dogfood instance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
     name: Create release on self-hosted dogfood instance
     needs: release
     steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
       - uses: getsentry/action-release@v1
         env:
           SENTRY_ORG: self-hosted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
           environment: production
           version: ${{ env.RELEASE_VERSION }}
           ignore_empty: true
+          ignore_missing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,16 +42,16 @@ jobs:
         run: |
           if [[ -n SENTRY_RELEASE ]]; then
             # Our releases are on 15th of each month so go back 14 days (a fortnight)
-            DATE_PART=$(date -d ''-1 fortnight'' +''%y.%-m'')
+            DATE_PART=$(date -d '-1 fortnight' '+%y.%-m')
             declare -i PATCH_VERSION=0
             while gh api --silent "repos/:owner/:repo/git/ref/tags/$DATE_PART.$PATCH_VERSION" 2>/dev/null; do
               PATCH_VERSION+=1
             done
             echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
-            curl -sL https://sentry.io/get-cli/ | bash
           else
             echo "RELEASE_VERSION=SENTRY_RELEASE" >> $GITHUB_ENV
           fi
+          curl -sL https://sentry.io/get-cli/ | bash
 
           # Create new Sentry release
           sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases new -p $SENTRY_PROJECT $RELEASE_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,31 +32,13 @@ jobs:
       #     force: ${{ github.event.inputs.force }}
       #     calver: true
       - name: Create new release in self-hosted Sentry
+        uses: getsentry/action-release@v1
         env:
-          SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
+          # SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
           SENTRY_ORG: self-hosted
           SENTRY_PROJECT: installer
           SENTRY_URL: https://self-hosted.getsentry.net/
           SENTRY_AUTH_TOKEN: ${{ secrets.SELF_HOSTED_RELEASE_TOKEN }}
-          SENTRY_RELEASE: ${{ github.event.inputs.version }}
-        run: |
-          if [[ -n SENTRY_RELEASE ]]; then
-            # Our releases are on 15th of each month so go back 14 days (a fortnight)
-            DATE_PART=$(date -d '-1 fortnight' '+%y.%-m')
-            declare -i PATCH_VERSION=0
-            while gh api --silent "repos/:owner/:repo/git/ref/tags/$DATE_PART.$PATCH_VERSION" 2>/dev/null; do
-              PATCH_VERSION+=1
-            done
-            RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}
-          else
-            RELEASE_VERSION=SENTRY_RELEASE
-          fi
-          curl -sL https://sentry.io/get-cli/ | bash
-
-          # Create new Sentry release
-          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases new -p $SENTRY_PROJECT $RELEASE_VERSION
-          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases set-commits --auto $RELEASE_VERSION
-          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases finalize $RELEASE_VERSION
-
-          # Create new deploy for this Sentry release
-          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases deploys $RELEASE_VERSION new -e production
+        with:
+          environment: production
+          version: {{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
             while gh api --silent "repos/:owner/:repo/git/ref/tags/$DATE_PART.$PATCH_VERSION" 2>/dev/null; do
               PATCH_VERSION+=1
             done
-            echo "RELEASE_VERSION=${{DATE_PART}}.${{PATCH_VERSION}}" >> $GITHUB_ENV;
+            echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
             curl -sL https://sentry.io/get-cli/ | bash
           else
             echo "RELEASE_VERSION=SENTRY_RELEASE" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SELF_HOSTED_RELEASE_TOKEN }}
         with:
           environment: production
-          version: {{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
       - name: Prepare release
+        id: prepare-release
         uses: getsentry/action-prepare-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
@@ -31,6 +32,8 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           calver: true
+        outputs:
+          release-version: ${{ env.RELEASE_VERSION }}
       - name: Create new release in self-hosted Sentry
         uses: getsentry/action-release@v1
         env:
@@ -40,6 +43,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SELF_HOSTED_RELEASE_TOKEN }}
         with:
           environment: production
-          version: ${{ env.RELEASE_VERSION }}
+          version: ${{ steps.prepare-release.outputs.release-version }}
           ignore_empty: true
           ignore_missing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,9 @@ jobs:
           force: ${{ github.event.inputs.force }}
           calver: true
         outputs:
-          release-version: ${{ env.RELEASE_VERSION }}
+          release-version:
+            description: "Release version"
+            value: ${{ env.RELEASE_VERSION }}
       - name: Create new release in self-hosted Sentry
         uses: getsentry/action-release@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           calver: true
-      outputs:
-        release-version: ${{ env.RELEASE_VERSION }}
+    outputs:
+      release-version: ${{ env.RELEASE_VERSION }}
   dogfood-release:
     if: github.repository_owner == 'getsentry'
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,15 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           calver: true
-        outputs:
-          release-version:
-            description: "Release version"
-            value: ${{ env.RELEASE_VERSION }}
-      - name: Create new release in self-hosted Sentry
-        uses: getsentry/action-release@v1
+      outputs:
+        release-version: ${{ env.RELEASE_VERSION }}
+  dogfood-release:
+    if: github.repository_owner == 'getsentry'
+    runs-on: ubuntu-latest
+    name: Create release on self-hosted dogfood instance
+    needs: release
+    steps:
+      - uses: getsentry/action-release@v1
         env:
           SENTRY_ORG: self-hosted
           SENTRY_PROJECT: installer
@@ -45,6 +48,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SELF_HOSTED_RELEASE_TOKEN }}
         with:
           environment: production
-          version: ${{ steps.prepare-release.outputs.release-version }}
+          version: ${{ needs.release.outputs.release-version }}
           ignore_empty: true
           ignore_missing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Create new release in self-hosted Sentry
         uses: getsentry/action-release@v1
         env:
-          # SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
           SENTRY_ORG: self-hosted
           SENTRY_PROJECT: installer
           SENTRY_URL: https://self-hosted.getsentry.net/
@@ -42,3 +41,4 @@ jobs:
         with:
           environment: production
           version: ${{ env.RELEASE_VERSION }}
+          ignore_empty: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
-      # - name: Prepare release
-      #   uses: getsentry/action-prepare-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
-      #   with:
-      #     version: ${{ github.event.inputs.version }}
-      #     force: ${{ github.event.inputs.force }}
-      #     calver: true
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+          calver: true
       - name: Create new release in self-hosted Sentry
         uses: getsentry/action-release@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
-      - name: Prepare release
-        uses: getsentry/action-prepare-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
-        with:
-          version: ${{ github.event.inputs.version }}
-          force: ${{ github.event.inputs.force }}
-          calver: true
+      # - name: Prepare release
+      #   uses: getsentry/action-prepare-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+      #   with:
+      #     version: ${{ github.event.inputs.version }}
+      #     force: ${{ github.event.inputs.force }}
+      #     calver: true
       - name: Create new release in self-hosted Sentry
         env:
           SENTRY_DSN: 'https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
@@ -40,12 +40,23 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SELF_HOSTED_RELEASE_TOKEN }}
           SENTRY_RELEASE: ${{ github.event.inputs.version }}
         run: |
-          curl -sL https://sentry.io/get-cli/ | bash
+          if [[ -n SENTRY_RELEASE ]]; then
+            # Our releases are on 15th of each month so go back 14 days (a fortnight)
+            DATE_PART=$(date -d ''-1 fortnight'' +''%y.%-m'')
+            declare -i PATCH_VERSION=0
+            while gh api --silent "repos/:owner/:repo/git/ref/tags/$DATE_PART.$PATCH_VERSION" 2>/dev/null; do
+              PATCH_VERSION+=1
+            done
+            echo "RELEASE_VERSION=${{DATE_PART}}.${{PATCH_VERSION}}" >> $GITHUB_ENV;
+            curl -sL https://sentry.io/get-cli/ | bash
+          else
+            echo "RELEASE_VERSION=SENTRY_RELEASE" >> $GITHUB_ENV
+          fi
 
           # Create new Sentry release
-          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases set-commits --auto $SENTRY_RELEASE
-          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases finalize $SENTRY_RELEASE
+          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases new -p $SENTRY_PROJECT $RELEASE_VERSION
+          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases set-commits --auto $RELEASE_VERSION
+          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases finalize $RELEASE_VERSION
 
           # Create new deploy for this Sentry release
-          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases deploys $SENTRY_RELEASE new -e production
+          sentry-cli --auth-token $SENTRY_AUTH_TOKEN releases deploys $RELEASE_VERSION new -e production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,9 @@ jobs:
             while gh api --silent "repos/:owner/:repo/git/ref/tags/$DATE_PART.$PATCH_VERSION" 2>/dev/null; do
               PATCH_VERSION+=1
             done
-            echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
+            RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}
           else
-            echo "RELEASE_VERSION=SENTRY_RELEASE" >> $GITHUB_ENV
+            RELEASE_VERSION=SENTRY_RELEASE
           fi
           curl -sL https://sentry.io/get-cli/ | bash
 


### PR DESCRIPTION
uses the action-release/v1 to handle releases for dogfood since that's much easier!!
https://github.com/getsentry/action-release

Apparently, the version of the release is set earlier in the prepare release action and set as an environment variable `env.RELEASE_VERSION` so I'm using that. The `ignore_missing` and `ignore_empty` flags are set to avoid erroring out of release script.