### PR TITLE
Do not send event on INT signal

### DIFF
--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -175,7 +175,7 @@ cleanup () {
       done
     fi
     echo "$traceback"
-    echo "$1"
+
     if [[ "$REPORT_SELF_HOSTED_ISSUES" == 1 && "$1" != "INT" ]]; then
       local event_hash=$(echo -n "$cmd_exit $traceback" | docker run -i --rm busybox md5sum | cut -d' ' -f1)
       send_event "$event_hash" "$cmd_exit"

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -176,6 +176,7 @@ cleanup () {
     fi
     echo "$traceback"
 
+    # Only send event when report issues flag is set and if trap signal is not INT (ctrl+c)
     if [[ "$REPORT_SELF_HOSTED_ISSUES" == 1 && "$1" != "INT" ]]; then
       local event_hash=$(echo -n "$cmd_exit $traceback" | docker run -i --rm busybox md5sum | cut -d' ' -f1)
       send_event "$event_hash" "$cmd_exit"

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -175,8 +175,8 @@ cleanup () {
       done
     fi
     echo "$traceback"
-
-    if [ "$REPORT_SELF_HOSTED_ISSUES" == 1 ]; then
+    echo "$1"
+    if [[ "$REPORT_SELF_HOSTED_ISSUES" == 1 && "$1" != "INT" ]]; then
       local event_hash=$(echo -n "$cmd_exit $traceback" | docker run -i --rm busybox md5sum | cut -d' ' -f1)
       send_event "$event_hash" "$cmd_exit"
     fi


### PR DESCRIPTION
Right now, if someone presses ctrl+c, the event is sent to our dogfood instance. This removes that so we hopefully will see reduced noise