### PR TITLE
ref: upgrade actions/setup-python to avoid set-output deprecation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos