### PR TITLE
Add --skip-requirements to install.sh and enable SUPPORTS_SSE42 override

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,9 +17,6 @@ source error-handling.sh
 # We set the trap at the top level so that we get better tracebacks.
 trap_with_arg cleanup ERR INT TERM EXIT
 source check-latest-commit.sh
-if [[ ! "$SKIP_REQUIREMENTS" -eq 1 ]]; then
-  source check-minimum-requirements.sh
-fi
 
 # Let's go! Start impacting things.
 source turn-things-off.sh

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,9 @@ source error-handling.sh
 # We set the trap at the top level so that we get better tracebacks.
 trap_with_arg cleanup ERR INT TERM EXIT
 source check-latest-commit.sh
-source check-minimum-requirements.sh
+if [[ ! "$SKIP_REQUIREMENTS" -eq 1 ]]; then
+  source check-minimum-requirements.sh
+fi
 
 # Let's go! Start impacting things.
 source turn-things-off.sh

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ source error-handling.sh
 # We set the trap at the top level so that we get better tracebacks.
 trap_with_arg cleanup ERR INT TERM EXIT
 source check-latest-commit.sh
+source check-minimum-requirements.sh
 
 # Let's go! Start impacting things.
 source turn-things-off.sh

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -52,7 +52,7 @@ fi
 # On KVM, cpuinfo could falsely not report SSE 4.2 support, so skip the check. https://github.com/ClickHouse/ClickHouse/issues/20#issuecomment-226849297
 # This may also happen on other virtualization software such as on VMWare ESXi hosts.
 IS_KVM=$(docker run --rm busybox grep -c 'Common KVM processor' /proc/cpuinfo || :)
-if [[ ! "$SUPPORTS_SSE42" -eq 1 && "$IS_KVM" -eq 0 && "$DOCKER_ARCH" = "x86_64" ]]; then
+if [[ ! "$SKIP_SSE42_REQUIREMENTS" -eq 1 && "$IS_KVM" -eq 0 && "$DOCKER_ARCH" = "x86_64" ]]; then
   SUPPORTS_SSE42=$(docker run --rm busybox grep -c sse4_2 /proc/cpuinfo || :)
   if [[ "$SUPPORTS_SSE42" -eq 0 ]]; then
     echo "FAIL: The CPU your machine is running on does not support the SSE 4.2 instruction set, which is required for one of the services Sentry uses (Clickhouse). See https://github.com/getsentry/self-hosted/issues/340 for more info."

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -50,8 +50,9 @@ fi
 
 #SSE4.2 required by Clickhouse (https://clickhouse.yandex/docs/en/operations/requirements/)
 # On KVM, cpuinfo could falsely not report SSE 4.2 support, so skip the check. https://github.com/ClickHouse/ClickHouse/issues/20#issuecomment-226849297
+# This may also happen on other virtualization software such as on VMWare ESXi hosts.
 IS_KVM=$(docker run --rm busybox grep -c 'Common KVM processor' /proc/cpuinfo || :)
-if [[ "$IS_KVM" -eq 0 && "$DOCKER_ARCH" = "x86_64" ]]; then
+if [[ ! "$SUPPORTS_SSE42" -eq 1 && "$IS_KVM" -eq 0 && "$DOCKER_ARCH" = "x86_64" ]]; then
   SUPPORTS_SSE42=$(docker run --rm busybox grep -c sse4_2 /proc/cpuinfo || :)
   if [[ "$SUPPORTS_SSE42" -eq 0 ]]; then
     echo "FAIL: The CPU your machine is running on does not support the SSE 4.2 instruction set, which is required for one of the services Sentry uses (Clickhouse). See https://github.com/getsentry/self-hosted/issues/340 for more info."

--- a/install/parse-cli.sh
+++ b/install/parse-cli.sh
@@ -18,6 +18,9 @@ Options:
                           branch of a \`self-hosted\` Git working copy.
  --skip-user-creation   Skip the initial user creation prompt (ideal for non-
                           interactive installs).
+ --skip-requirements    Skip checking that your environment meets the minimum
+                          requirements to run Sentry. Only do this if you know
+                          what you are doing.
  --report-self-hosted-issues
                         Report error and performance data about your self-hosted
                           instance upstream to Sentry. See sentry.io/privacy for
@@ -41,6 +44,7 @@ SKIP_USER_CREATION="${SKIP_USER_CREATION:-}"
 MINIMIZE_DOWNTIME="${MINIMIZE_DOWNTIME:-}"
 SKIP_COMMIT_CHECK="${SKIP_COMMIT_CHECK:-}"
 REPORT_SELF_HOSTED_ISSUES="${REPORT_SELF_HOSTED_ISSUES:-}"
+SKIP_REQUIREMENTS="${SKIP_REQUIREMENTS:-}"
 
 while (($#)); do
   case "$1" in
@@ -61,6 +65,7 @@ while (($#)); do
   --skip-commit-check) SKIP_COMMIT_CHECK=1 ;;
   --report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=1 ;;
   --no-report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=0 ;;
+  --skip-requirements) SKIP_REQUIREMENTS=1 ;;
   --) ;;
   *)
     echo "Unexpected argument: $1. Use --help for usage information."

--- a/install/parse-cli.sh
+++ b/install/parse-cli.sh
@@ -17,10 +17,11 @@ Options:
  --skip-commit-check    Skip the check for the latest commit when on the master
                           branch of a \`self-hosted\` Git working copy.
  --skip-user-creation   Skip the initial user creation prompt (ideal for non-
-                          interactive installs).
- --skip-requirements    Skip checking that your environment meets the minimum
-                          requirements to run Sentry. Only do this if you know
-                          what you are doing.
+                          	interactive installs).
+ --skip-sse42-requirements
+			Skip checking that your environment meets the
+			  requirements to run Sentry. Only do this if you know
+			  what you are doing.
  --report-self-hosted-issues
                         Report error and performance data about your self-hosted
                           instance upstream to Sentry. See sentry.io/privacy for
@@ -44,7 +45,7 @@ SKIP_USER_CREATION="${SKIP_USER_CREATION:-}"
 MINIMIZE_DOWNTIME="${MINIMIZE_DOWNTIME:-}"
 SKIP_COMMIT_CHECK="${SKIP_COMMIT_CHECK:-}"
 REPORT_SELF_HOSTED_ISSUES="${REPORT_SELF_HOSTED_ISSUES:-}"
-SKIP_REQUIREMENTS="${SKIP_REQUIREMENTS:-}"
+SKIP_SSE42_REQUIREMENTS="${SKIP_SSE42_REQUIREMENTS:-}"
 
 while (($#)); do
   case "$1" in
@@ -65,7 +66,7 @@ while (($#)); do
   --skip-commit-check) SKIP_COMMIT_CHECK=1 ;;
   --report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=1 ;;
   --no-report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=0 ;;
-  --skip-requirements) SKIP_REQUIREMENTS=1 ;;
+  --skip-sse42-requirements) SKIP_SSE42_REQUIREMENTS=1 ;;
   --) ;;
   *)
     echo "Unexpected argument: $1. Use --help for usage information."


### PR DESCRIPTION
I've discovered that the check for SSE4.2 added in #361 fails on virtualization solutions other than KVM - possibly what the author of #1782 is having trouble with too.

Trying to install Sentry on a virtual machine running on a VMWare ESXi host ("ESXi 6.5 and later (VM version 13)"), it reports running on processors that _definitely_ [support SSE4.2](https://ark.intel.com/content/www/us/en/ark/products/120495/intel-xeon-gold-6154-processor-24-75m-cache-3-00-ghz.html):

```cat /proc/cpuinfo
model name	: Intel(R) Xeon(R) Gold 6154 CPU @ 3.00GHz
```

But this is not reported in their `flags`.

In this case, this is likely to do with our VM cluster having old servers which really don't have SSE4.2 and so [VWMare targets the lowest possible instruction set](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-8B226625-4923-410C-B7AF-51BCD2806A3B.html) -- or, there's just a bug or a misconfigured option which means SSE4.2 isn't reported for CPUs which really do support it.

Obviously the right solution is "fix that underlying problem", but that's outside of our control (virtual machines managed by a central IT department, long lead time on updating the VMWare environment, etc).  

Luckily, I was able to run the executable mentioned in [this comment](https://github.com/ClickHouse/ClickHouse/issues/20#issuecomment-226853025) on a ClickHouse issue, which verified that yes, our virtual machine _does_ support SSE4.2, it just doesn't report it.

Bypassing the check in `check-minimum-requirements.sh`, I was able to install Sentry just fine on the VM.

Decided to clean it up and make it part of the install script - in two ways - being able to override `SUPPORTS_SSE42`, so you could run `SUPPORTS_SSE42=1 ./install.sh`, but also more generally skip requirements checking with an "I know, my set-up is weird, carry on anyway" flag to the script, `--skip-requirements`


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
