### PR TITLE
Disable cache when rebuilding Docker images

### DIFF
--- a/install/build-docker-images.sh
+++ b/install/build-docker-images.sh
@@ -3,8 +3,8 @@ echo "${_group}Building and tagging Docker images ..."
 echo ""
 # Build any service that provides the image sentry-self-hosted-local first,
 # as it is used as the base image for sentry-cleanup-self-hosted-local.
-$dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm web
-$dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm
+$dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm --no-cache web
+$dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm --no-cache
 # Used in error-handling.sh for error envelope payloads
 docker build -t sentry-self-hosted-jq-local $basedir/jq
 echo ""


### PR DESCRIPTION
With the cache enabled, the steps in `enhance-image.sh` were not being run again on a new base image. This resulted in a new image being built without the proper additional libraries installed.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
