### PR TITLE
Reference paths relative to the current script or project root

### DIFF
--- a/_integration-test/custom-ca-roots/setup.sh
+++ b/_integration-test/custom-ca-roots/setup.sh
@@ -1,10 +1,8 @@
-#! /usr/bin/env bash
 set -e
+export COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yml:$PROJECT_ROOT/custom-ca-roots/docker-compose.test.yml"
 
-export COMPOSE_FILE="../docker-compose.yml:./custom-ca-roots/docker-compose.test.yml"
-
-TEST_NGINX_CONF_PATH="./custom-ca-roots/nginx"
-CUSTOM_CERTS_PATH="../certificates"
+TEST_NGINX_CONF_PATH="$PROJECT_ROOT/custom-ca-roots/nginx"
+CUSTOM_CERTS_PATH="$PROJECT_ROOT/certificates"
 
 # generate tightly constrained CA
 # NB: `-addext` requires LibreSSL 3.1.0+, or OpenSSL (brew install openssl)
@@ -42,6 +40,6 @@ openssl req -x509 -newkey rsa:2048 -nodes -days 1 -keyout $TEST_NGINX_CONF_PATH/
 
 # openssl x509 -in nginx/fake.test.crt -text -noout
 
-cp ./custom-ca-roots/test.py ../sentry/test-custom-ca-roots.py
+cp "$PROJECT_ROOT/custom-ca-roots/test.py" "$PROJECT_ROOT/sentry/test-custom-ca-roots.py"
 
 $dc up -d fixture-custom-ca-roots

--- a/_integration-test/custom-ca-roots/teardown.sh
+++ b/_integration-test/custom-ca-roots/teardown.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 $dc rm -s -f -v fixture-custom-ca-roots
-rm -f ../certificates/test-custom-ca-roots.crt ../sentry/test-custom-ca-roots.py
+rm -f "$PROJECT_ROOT/certificates/test-custom-ca-roots.crt" "$PROJECT_ROOT/sentry/test-custom-ca-roots.py"
 unset COMPOSE_FILE

--- a/_integration-test/ensure-customizations-not-present.sh
+++ b/_integration-test/ensure-customizations-not-present.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
-source "$(dirname $0)/../install/_lib.sh"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/../install/_lib.sh"
 
-source ../install/dc-detect-version.sh
+source "$PROJECT_ROOT/install/dc-detect-version.sh"
 
 # Negated version of ensure-customizations-work.sh, make changes in sync
 echo "${_group}Ensure customizations not present"

--- a/_integration-test/ensure-customizations-work.sh
+++ b/_integration-test/ensure-customizations-work.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
-source "$(dirname $0)/../install/_lib.sh"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/../install/_lib.sh"
 
-source ../install/dc-detect-version.sh
+source "$PROJECT_ROOT/install/dc-detect-version.sh"
 
 # Negated version of ensure-customizations-not-present.sh, make changes in sync
 echo "${_group}Ensure customizations work"

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
-source "$(dirname $0)/../install/_lib.sh"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/../install/_lib.sh"
 
-source ../install/dc-detect-version.sh
+source "$PROJECT_ROOT/install/dc-detect-version.sh"
 
 echo "${_group}Setting up variables and helpers ..."
 export SENTRY_TEST_HOST="${SENTRY_TEST_HOST:-http://localhost:9000}"
@@ -131,7 +132,7 @@ echo '------------------------------------------'
 echo "${_endgroup}"
 
 echo "${_group}Test custom CAs work ..."
-source ./custom-ca-roots/setup.sh
+source "$PROJECT_ROOT/_integration-test/custom-ca-roots/setup.sh"
 $dcr --no-deps web python3 /etc/sentry/test-custom-ca-roots.py
-source ./custom-ca-roots/teardown.sh
+source "$PROJECT_ROOT/_integration-test/custom-ca-roots/teardown.sh"
 echo "${_endgroup}"

--- a/_unit-test/_test_setup.sh
+++ b/_unit-test/_test_setup.sh
@@ -1,5 +1,7 @@
 set -euo pipefail
-source "$(dirname $0)/../install/_lib.sh"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/../install/_lib.sh"
 
 rm -rf /tmp/sentry-self-hosted-test-sandbox.*
 _SANDBOX="$(mktemp -d /tmp/sentry-self-hosted-test-sandbox.XXX)"
@@ -13,7 +15,7 @@ teardown() {
 }
 
 setup() {
-  cd ..
+  cd "$PROJECT_ROOT"
 
   # Clone the local repo into a temp dir. FWIW `git clone --local` breaks for
   # me because it depends on hard-linking, which doesn't work across devices,

--- a/_unit-test/create-docker-volumes-test.sh
+++ b/_unit-test/create-docker-volumes-test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-source "$(dirname $0)/_test_setup.sh"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/_test_setup.sh"
 
 get_volumes() {
   # If grep returns no strings, we still want to return without error
@@ -20,9 +22,9 @@ before=$(get_volumes)
 
 test "$before" == "" || test "$before" == "$expected_volumes"
 
-source create-docker-volumes.sh
-source create-docker-volumes.sh
-source create-docker-volumes.sh
+source "$PROJECT_ROOT/install/create-docker-volumes.sh"
+source "$PROJECT_ROOT/install/create-docker-volumes.sh"
+source "$PROJECT_ROOT/install/create-docker-volumes.sh"
 
 after=$(get_volumes)
 test "$after" == "$expected_volumes"

--- a/_unit-test/ensure-relay-credentials-test.sh
+++ b/_unit-test/ensure-relay-credentials-test.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
-source "$(dirname $0)/_test_setup.sh"
-source dc-detect-version.sh
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/_test_setup.sh"
+
+source "$PROJECT_ROOT/install/dc-detect-version.sh"
 
 # using _file format for these variables since there is a creds defined in dc-detect-version.sh
-cfg_file="../relay/config.yml"
-creds_file="../relay/credentials.json"
+cfg_file="$PROJECT_ROOT/relay/config.yml"
+creds_file="$PROJECT_ROOT/relay/credentials.json"
 
 # Relay files don't exist in a clean clone.
 test ! -f $cfg_file
 test ! -f $creds_file
 
 # Running the install script adds them.
-source ensure-relay-credentials.sh
+source "$PROJECT_ROOT/install/ensure-relay-credentials.sh"
 test -f $cfg_file
 test -f $creds_file
 test "$(jq -r 'keys[2]' $creds_file)" = "secret_key"
@@ -19,7 +22,7 @@ test "$(jq -r 'keys[2]' $creds_file)" = "secret_key"
 # If the files exist we don't touch it.
 echo GARBAGE >$cfg_file
 echo MOAR GARBAGE >$creds_file
-source ensure-relay-credentials.sh
+source "$PROJECT_ROOT/install/ensure-relay-credentials.sh"
 test "$(cat $cfg_file)" = "GARBAGE"
 test "$(cat $creds_file)" = "MOAR GARBAGE"
 

--- a/_unit-test/error-handling-test.sh
+++ b/_unit-test/error-handling-test.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-source "$(dirname $0)/_test_setup.sh"
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/_test_setup.sh"
 
 export REPORT_SELF_HOSTED_ISSUES=1
 
-source error-handling.sh
+source "$PROJECT_ROOT/install/error-handling.sh"
 
 # mock send_envelope
 send_envelope() {
@@ -12,7 +14,7 @@ send_envelope() {
 
 export -f send_envelope
 echo "Testing initial send_event"
-export log_path="$basedir/test_log.txt"
+export log_path="$PROJECT_ROOT/test_log.txt"
 echo "Test Logs" >"$log_path"
 echo "Error Msg" >>"$log_path"
 breadcrumbs=$(generate_breadcrumb_json | sed '$d' | jq -s -c)
@@ -20,7 +22,7 @@ SEND_EVENT_RESPONSE=$(send_event "12345123451234512345123451234512" "Test exited
 rm "$log_path"
 test "$SEND_EVENT_RESPONSE" == 'Test Sending sentry-envelope-12345123451234512345123451234512'
 ENVELOPE_CONTENTS=$(cat /tmp/sentry-envelope-12345123451234512345123451234512)
-test "$ENVELOPE_CONTENTS" == "$(cat "$basedir/_unit-test/snapshots/sentry-envelope-12345123451234512345123451234512")"
+test "$ENVELOPE_CONTENTS" == "$(cat "$PROJECT_ROOT/_unit-test/snapshots/sentry-envelope-12345123451234512345123451234512")"
 echo "Pass."
 
 echo "Testing send_event duplicate"

--- a/_unit-test/geoip-test.sh
+++ b/_unit-test/geoip-test.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
-source "$(dirname $0)/_test_setup.sh"
 
-mmdb="../geoip/GeoLite2-City.mmdb"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/_test_setup.sh"
+
+mmdb="$PROJECT_ROOT/geoip/GeoLite2-City.mmdb"
 
 # Starts with no mmdb, ends up with empty.
 test ! -f $mmdb
-source geoip.sh
+source "$PROJECT_ROOT/install/geoip.sh"
 diff -rub $mmdb $mmdb.empty
 
 # Doesn't clobber existing, though.
 echo GARBAGE >$mmdb
-source geoip.sh
+source "$PROJECT_ROOT/install/geoip.sh"
 test "$(cat $mmdb)" = "GARBAGE"
 
 report_success

--- a/clean.sh
+++ b/clean.sh
@@ -9,9 +9,8 @@ if [ -n "${DEBUG:-}" ]; then
   set -x
 fi
 
-cd "$(dirname $0)"
-
-source install/dc-detect-version.sh
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/install/dc-detect-version.sh"
 
 function confirm() {
   read -p "$1 [y/n] " confirmation

--- a/install.sh
+++ b/install.sh
@@ -7,29 +7,30 @@ if [[ -n "$MSYSTEM" ]]; then
   exit 1
 fi
 
-source "$(dirname $0)/install/_lib.sh" # does a `cd .../install/`, among other things
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/install/_lib.sh"
 
 # Pre-flight. No impact yet.
-source parse-cli.sh
-source detect-platform.sh
-source dc-detect-version.sh
-source error-handling.sh
+source "$PROJECT_ROOT/install/parse-cli.sh"
+source "$PROJECT_ROOT/install/detect-platform.sh"
+source "$PROJECT_ROOT/install/dc-detect-version.sh"
+source "$PROJECT_ROOT/install/error-handling.sh"
 # We set the trap at the top level so that we get better tracebacks.
 trap_with_arg cleanup ERR INT TERM EXIT
-source check-latest-commit.sh
-source check-minimum-requirements.sh
+source "$PROJECT_ROOT/install/check-latest-commit.sh"
+source "$PROJECT_ROOT/install/check-minimum-requirements.sh"
 
 # Let's go! Start impacting things.
-source turn-things-off.sh
-source create-docker-volumes.sh
-source ensure-files-from-examples.sh
-source ensure-relay-credentials.sh
-source generate-secret-key.sh
-source update-docker-images.sh
-source build-docker-images.sh
-source install-wal2json.sh
-source bootstrap-snuba.sh
-source create-kafka-topics.sh
-source set-up-and-migrate-database.sh
-source geoip.sh
-source wrap-up.sh
+source "$PROJECT_ROOT/install/turn-things-off.sh"
+source "$PROJECT_ROOT/install/create-docker-volumes.sh"
+source "$PROJECT_ROOT/install/ensure-files-from-examples.sh"
+source "$PROJECT_ROOT/install/ensure-relay-credentials.sh"
+source "$PROJECT_ROOT/install/generate-secret-key.sh"
+source "$PROJECT_ROOT/install/update-docker-images.sh"
+source "$PROJECT_ROOT/install/build-docker-images.sh"
+source "$PROJECT_ROOT/install/install-wal2json.sh"
+source "$PROJECT_ROOT/install/bootstrap-snuba.sh"
+source "$PROJECT_ROOT/install/create-kafka-topics.sh"
+source "$PROJECT_ROOT/install/set-up-and-migrate-database.sh"
+source "$PROJECT_ROOT/install/geoip.sh"
+source "$PROJECT_ROOT/install/wrap-up.sh"

--- a/install/build-docker-images.sh
+++ b/install/build-docker-images.sh
@@ -6,7 +6,7 @@ echo ""
 $dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm web
 $dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm
 # Used in error-handling.sh for error envelope payloads
-docker build -t sentry-self-hosted-jq-local $basedir/jq
+docker build -t sentry-self-hosted-jq-local "$PROJECT_ROOT/jq"
 echo ""
 echo "Docker images built."
 

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -1,6 +1,7 @@
 echo "${_group}Checking minimum requirements ..."
 
-source "$(dirname $0)/_min-requirements.sh"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/_min-requirements.sh"
 
 # Check the version of $1 is greater than or equal to $2 using sort. Note: versions must be stripped of "v"
 function vergte() {

--- a/install/ensure-files-from-examples.sh
+++ b/install/ensure-files-from-examples.sh
@@ -2,6 +2,6 @@ echo "${_group}Ensuring files from examples ..."
 
 ensure_file_from_example "$SENTRY_CONFIG_PY"
 ensure_file_from_example "$SENTRY_CONFIG_YML"
-ensure_file_from_example '../symbolicator/config.yml'
+ensure_file_from_example "$PROJECT_ROOT/symbolicator/config.yml"
 
 echo "${_endgroup}"

--- a/install/ensure-relay-credentials.sh
+++ b/install/ensure-relay-credentials.sh
@@ -1,7 +1,7 @@
 echo "${_group}Ensuring Relay credentials ..."
 
-RELAY_CONFIG_YML="../relay/config.yml"
-RELAY_CREDENTIALS_JSON="../relay/credentials.json"
+RELAY_CONFIG_YML="$PROJECT_ROOT/relay/config.yml"
+RELAY_CREDENTIALS_JSON="$PROJECT_ROOT/relay/credentials.json"
 
 ensure_file_from_example $RELAY_CONFIG_YML
 

--- a/install/geoip.sh
+++ b/install/geoip.sh
@@ -1,10 +1,8 @@
 echo "${_group}Setting up GeoIP integration ..."
 
 install_geoip() {
-  cd ../geoip
-
-  local mmdb='GeoLite2-City.mmdb'
-  local conf='GeoIP.conf'
+  local mmdb="$PROJECT_ROOT/geoip/GeoLite2-City.mmdb"
+  local conf="$PROJECT_ROOT/geoip/GeoIP.conf"
   local result='Done'
 
   echo "Setting up IP address geolocation ..."
@@ -29,8 +27,6 @@ install_geoip() {
     echo "$result updating IP address geolocation database."
   fi
   echo "$result setting up IP address geolocation."
-
-  cd ../install
 }
 
 install_geoip

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -1,6 +1,7 @@
 echo "${_group}Downloading and installing wal2json ..."
 
-FILE_TO_USE="../postgres/wal2json/wal2json.so"
+WAL2JSON_DIR="$PROJECT_ROOT/postgres/wal2json"
+FILE_TO_USE="$WAL2JSON_DIR/wal2json.so"
 ARCH=$(uname -m)
 FILE_NAME="wal2json-Linux-$ARCH-glibc.so"
 
@@ -25,13 +26,13 @@ else
   VERSION=$WAL2JSON_VERSION
 fi
 
-mkdir -p ../postgres/wal2json
-if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
-  mkdir -p "../postgres/wal2json/$VERSION"
+mkdir -p "$WAL2JSON_DIR"
+if [ ! -f "$WAL2JSON_DIR/$VERSION/$FILE_NAME" ]; then
+  mkdir -p "$WAL2JSON_DIR/$VERSION"
   docker_curl -L \
     "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
-    >"../postgres/wal2json/$VERSION/$FILE_NAME"
+    >"$WAL2JSON_DIR/$VERSION/$FILE_NAME"
 fi
-cp "../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
+cp "$WAL2JSON_DIR/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 
 echo "${_endgroup}"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd $SCRIPT_DIR/..
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR/.."
 
 OLD_VERSION="$1"
 NEW_VERSION="$2"

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd $SCRIPT_DIR/..
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR/.."
 
 # Bring master back to nightlies after merge from release branch
 git checkout master && git pull


### PR DESCRIPTION
Before this PR:
- some scripts change the current working directory and use relative paths
- different approaches are taken to know which directory a script is running in
- paths are sometimes relative, sometimes absolute, sometimes traversing directories

After this PR:
- scripts do neither change nor care much about the current working directory
- a unified approach determines the directory of the current script
- paths are always relative to the project root

This should resolve an issue I already tried to fix with https://github.com/getsentry/self-hosted/pull/1798, where the contents of `./sentry` were not copied
into the built container image,
thus `enhance-image.sh` did not apply.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
