### PR TITLE
Fix jq usage

### DIFF
--- a/_unit-test/_test_setup.sh
+++ b/_unit-test/_test_setup.sh
@@ -4,6 +4,9 @@ source "$(dirname $0)/../install/_lib.sh"
 rm -rf /tmp/sentry-self-hosted-test-sandbox.*
 _SANDBOX="$(mktemp -d /tmp/sentry-self-hosted-test-sandbox.XXX)"
 
+source "$basedir/install/detect-platform.sh"
+docker build -t sentry-self-hosted-jq-local --platform=$DOCKER_PLATFORM "$basedir/jq"
+
 report_success() {
   echo "$(basename $0) - Success 👍"
 }

--- a/_unit-test/error-handling-test.sh
+++ b/_unit-test/error-handling-test.sh
@@ -15,7 +15,7 @@ echo "Testing initial send_event"
 export log_path="$basedir/test_log.txt"
 echo "Test Logs" >"$log_path"
 echo "Error Msg" >>"$log_path"
-breadcrumbs=$(generate_breadcrumb_json | sed '$d' | jq -s -c)
+breadcrumbs=$(generate_breadcrumb_json | sed '$d' | $jq -s -c)
 SEND_EVENT_RESPONSE=$(send_event "12345123451234512345123451234512" "Test exited with status 1" "{\"ignore\": \"me\"}" "$breadcrumbs")
 rm "$log_path"
 test "$SEND_EVENT_RESPONSE" == 'Test Sending sentry-envelope-12345123451234512345123451234512'

--- a/install/build-docker-images.sh
+++ b/install/build-docker-images.sh
@@ -6,7 +6,7 @@ echo ""
 $dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm web
 $dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm
 # Used in error-handling.sh for error envelope payloads
-docker build -t sentry-self-hosted-jq-local $basedir/jq
+docker build -t sentry-self-hosted-jq-local --platform=$DOCKER_PLATFORM $basedir/jq
 echo ""
 echo "Docker images built."
 

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -15,12 +15,7 @@ send_envelope() {
 
 generate_breadcrumb_json() {
   # Based on https://stackoverflow.com/a/1521498
-  while IFS="" read -r line || [ -n "$line" ]; do
-    $jq -n -c --arg message "$line" \
-      --arg category log \
-      --arg level info \
-      '$ARGS.named'
-  done <$log_path
+  cat $log_path | $jq -R -c 'split("\n") | {"message": (.[0]//""), "category": "log", "level": "info"}'
 }
 
 send_event() {

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -14,7 +14,6 @@ send_envelope() {
 }
 
 generate_breadcrumb_json() {
-  # Based on https://stackoverflow.com/a/1521498
   cat $log_path | $jq -R -c 'split("\n") | {"message": (.[0]//""), "category": "log", "level": "info"}'
 }
 

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -16,7 +16,7 @@ send_envelope() {
 generate_breadcrumb_json() {
   # Based on https://stackoverflow.com/a/1521498
   while IFS="" read -r line || [ -n "$line" ]; do
-    jq -n -c --arg message "$line" \
+    $jq -n -c --arg message "$line" \
       --arg category log \
       --arg level info \
       '$ARGS.named'
@@ -42,7 +42,7 @@ send_event() {
   local file_length=$(wc -c <$log_path | awk '{print $1}')
 
   # Add header for initial envelope information
-  jq -n -c --arg event_id "$event_hash" \
+  $jq -n -c --arg event_id "$event_hash" \
     --arg dsn "$SENTRY_DSN" \
     '$ARGS.named' >$envelope_file_path
   # Add header to specify the event type of envelope to be sent
@@ -56,16 +56,16 @@ send_event() {
   # Then we need the exception payload
   # https://develop.sentry.dev/sdk/event-payloads/exception/
   # but first we need to make the stacktrace which goes in the exception payload
-  frames=$(echo "$traceback_json" | jq -s -c)
-  stacktrace=$(jq -n -c --argjson frames "$frames" '$ARGS.named')
+  frames=$(echo "$traceback_json" | $jq -s -c)
+  stacktrace=$($jq -n -c --argjson frames "$frames" '$ARGS.named')
   exception=$(
-    jq -n -c --arg "type" Error \
+    $jq -n -c --arg "type" Error \
       --arg value "$error_msg" \
       --argjson stacktrace "$stacktrace" \
       '$ARGS.named'
   )
   event_body=$(
-    jq -n -c --arg level error \
+    $jq -n -c --arg level error \
       --argjson exception "{\"values\":[$exception]}" \
       --argjson breadcrumbs "{\"values\": $breadcrumbs}" \
       '$ARGS.named'
@@ -73,7 +73,7 @@ send_event() {
   echo "$event_body" >>$envelope_file_path
   # Add attachment to the event
   attachment=$(
-    jq -n -c --arg "type" attachment \
+    $jq -n -c --arg "type" attachment \
       --arg length $file_length \
       --arg content_type "text/plain" \
       --arg filename install_log.txt \
@@ -173,7 +173,7 @@ cleanup() {
     # Create the breadcrumb payload now before stacktrace is printed
     # https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
     # Use sed to remove the last line, that is reported through the error message
-    breadcrumbs=$(generate_breadcrumb_json | sed '$d' | jq -s -c)
+    breadcrumbs=$(generate_breadcrumb_json | sed '$d' | $jq -s -c)
     printf -v err '%s' "Error in ${BASH_SOURCE[1]}:${BASH_LINENO[0]}."
     printf -v cmd_exit '%s' "'$cmd' exited with status $retcode"
     printf '%s\n%s\n' "$err" "$cmd_exit"
@@ -187,7 +187,7 @@ cleanup() {
         local lineno=${BASH_LINENO[$i - 1]}
         local funcname=${FUNCNAME[$i]}
         JSON=$(
-          jq -n -c --arg filename $src \
+          $jq -n -c --arg filename $src \
             --arg "function" $funcname \
             --arg lineno "$lineno" \
             '{"filename": $filename, "function": $function, "lineno": $lineno|tonumber}'
@@ -195,7 +195,7 @@ cleanup() {
         # If we're in the stacktrace of the file we failed on, we can add a context line with the command run that failed
         if [[ $i -eq 1 ]]; then
           JSON=$(
-            jq -n -c --arg cmd "$cmd" \
+            $jq -n -c --arg cmd "$cmd" \
               --argjson json "$JSON" \
               '$json + {"context_line": $cmd}'
           )

--- a/jq/Dockerfile
+++ b/jq/Dockerfile
@@ -8,4 +8,4 @@ RUN set -x \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-CMD ["jq"]
+ENTRYPOINT ["jq"]


### PR DESCRIPTION
It seems that we missed jq running in docker not working right -- all the environments we test on install it as a dependency of unit tests :/

This fixes things to correctly invoke the jq command and changes from CMD to ENTRYPOINT so the container works correctly.

Fixes https://github.com/getsentry/self-hosted/issues/1810