### PR TITLE
(fix): Fix contributor PR e2e tests

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - "-e"
       - "-c"
       - |
-        git clone -b $BRANCH_NAME https://github.com/getsentry/self-hosted.git
+        git clone -b $BRANCH_NAME $_HEAD_REPO_URL
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > self-hosted/docker-compose.override.yml
     timeout: 60s
   - name: "gcr.io/$PROJECT_ID/docker-compose"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,8 @@ steps:
     id: clone-and-configure
     entrypoint: "bash"
     args:
+      # $BRANCH_NAME and $_HEAD_REPO_URL usage is documented here
+      # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
       - "-e"
       - "-c"
       - |


### PR DESCRIPTION
Our contributor e2e tests are failing since we're trying to clone a branch that doesn't exist on `https://github.com/getsentry/self-hosted.git`. Their branches only exist on their forked repos, so we need to reflect that in our e2e tests.

Also tested this out with contributor PR's [here](https://github.com/getsentry/self-hosted/pull/1821)