### PR TITLE
use postgres 14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
         hard: 10032
   postgres:
     <<: *restart_policy
-    image: "postgres:9.6"
+    image: "postgres:14.6"
     healthcheck:
       <<: *healthcheck_defaults
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided


### PR DESCRIPTION
Let's upgrade to Postgres14
If is faster and more modern. 
Postgres 9.6 is not supported anymore https://www.postgresql.org/support/versioning/

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
