### PR TITLE
Set higher kafka helathcheck timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,9 @@ services:
     healthcheck:
       <<: *healthcheck_defaults
       test: ["CMD-SHELL", "nc -z localhost 9092"]
+      interval: 3s
+      timeout: 600s
+      retries: 200
   clickhouse:
     <<: *restart_policy
     image: clickhouse-self-hosted-local


### PR DESCRIPTION
Ref https://github.com/getsentry/self-hosted/issues/1848

This increases the timeout of kafka based on failures such as https://self-hosted.getsentry.net/organizations/self-hosted/issues/18/events/d9ae718413c94659b20b785ab0bb8aa8/?project=3&query=is%3Aunresolved&referrer=previous-event&sort=freq&statsPeriod=14d
