### PR TITLE
ref: Retry wal2json download in installer

### DIFF
--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -17,7 +17,6 @@ docker_curl() {
 }
 
 if [[ $WAL2JSON_VERSION == "latest" ]]; then
-  # Retry up to 3 times, with 10 seconds between each attempt.
   VERSION=$(
     docker_curl https://api.github.com/repos/getsentry/wal2json/releases/latest |
       grep '"tag_name":' |


### PR DESCRIPTION
This has been causing a lot of failures in CI in Sentry and elsewhere recently. Hopefully the failures are flakes and this will work around them.


