### PR TITLE
fix(CI): use default curl retry mechanism for wal2json install

### DIFF
--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -11,7 +11,6 @@ docker_curl() {
     --connect-timeout 5 \
     --max-time 10 \
     --retry 5 \
-    --retry-delay 0 \
     --retry-max-time 60 \
     "$@"
 }


### PR DESCRIPTION
Retries were added to the `install-wal2json.sh` script in order to make CI pass, but the retries without any backoff cause rate limit issues. By default curl institutes exponential backoff

https://everything.curl.dev/usingcurl/downloads/retry

>  Using --retry-delay you can disable this exponential backoff algorithm and set your own delay between the attempts.

by not waiting any time between retries and launching CI jobs we shoot ourselves (and potentially other users) in the foot