### PR TITLE
ref: Move jq build to error-handling.sh, and use proxy config

### DIFF
--- a/_unit-test/error-handling-test.sh
+++ b/_unit-test/error-handling-test.sh
@@ -3,6 +3,9 @@ source "$(dirname $0)/_test_setup.sh"
 
 export REPORT_SELF_HOSTED_ISSUES=1
 
+# This is set up in dc-detect-version.sh, but for
+# our purposes we don't care about proxies.
+dbuild="docker build"
 source error-handling.sh
 
 # mock send_envelope

--- a/_unit-test/error-handling-test.sh
+++ b/_unit-test/error-handling-test.sh
@@ -39,7 +39,7 @@ export dc=':'
 echo "Test Logs" >"$log_path"
 CLEANUP_RESPONSE=$(cleanup ERROR)
 rm "$log_path"
-test "$CLEANUP_RESPONSE" == 'Error in ./_unit-test/error-handling-test.sh:37.
+test "$CLEANUP_RESPONSE" == 'Error in ./_unit-test/error-handling-test.sh:40.
 '\''local cmd="${BASH_COMMAND}"'\'' exited with status 0
 
 Cleaning up...'
@@ -51,7 +51,7 @@ export MINIMIZE_DOWNTIME=1
 echo "Test Logs" >"$log_path"
 CLEANUP_RESPONSE=$(cleanup ERROR)
 rm "$log_path"
-test "$CLEANUP_RESPONSE" == 'Error in ./_unit-test/error-handling-test.sh:49.
+test "$CLEANUP_RESPONSE" == 'Error in ./_unit-test/error-handling-test.sh:52.
 '\''local cmd="${BASH_COMMAND}"'\'' exited with status 0
 
 *NOT* cleaning up, to clean your environment run "docker compose stop".'

--- a/install/build-docker-images.sh
+++ b/install/build-docker-images.sh
@@ -7,8 +7,6 @@ $dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${ht
 for service in "$($dc config --services)"; do
   $dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm $service
 done
-# Used in error-handling.sh for error envelope payloads
-docker build -t sentry-self-hosted-jq-local --platform=$DOCKER_PLATFORM $basedir/jq
 echo ""
 echo "Docker images built."
 

--- a/install/build-docker-images.sh
+++ b/install/build-docker-images.sh
@@ -3,9 +3,9 @@ echo "${_group}Building and tagging Docker images ..."
 echo ""
 # Build any service that provides the image sentry-self-hosted-local first,
 # as it is used as the base image for sentry-cleanup-self-hosted-local.
-$dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm web
+$dcb --force-rm web
 for service in "$($dc config --services)"; do
-  $dc build --build-arg "http_proxy=${http_proxy:-}" --build-arg "https_proxy=${https_proxy:-}" --build-arg "no_proxy=${no_proxy:-}" --force-rm $service
+  $dcb --force-rm $service
 done
 echo ""
 echo "Docker images built."

--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -15,6 +15,9 @@ if [[ "$(basename $0)" = "install.sh" ]]; then
 else
   dc="$dc_base --ansi never"
 fi
+proxy_args="--build-arg http_proxy=${http_proxy:-} --build-arg https_proxy=${https_proxy:-} --build-arg no_proxy=${no_proxy:-}"
 dcr="$dc run --rm"
+dcb="$dc build $proxy_args"
+dbuild="docker build $proxy_args"
 
 echo "${_endgroup}"

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -4,6 +4,8 @@ export SENTRY_DSN='https://19555c489ded4769978daae92f2346ca@self-hosted.getsentr
 export SENTRY_ORG=self-hosted
 export SENTRY_PROJECT=installer
 
+$dbuild -t sentry-self-hosted-jq-local --platform=$DOCKER_PLATFORM $basedir/jq
+
 jq="docker run --rm -i sentry-self-hosted-jq-local"
 sentry_cli="docker run --rm -v /tmp:/work -e SENTRY_ORG=$SENTRY_ORG -e SENTRY_PROJECT=$SENTRY_PROJECT -e SENTRY_DSN=$SENTRY_DSN getsentry/sentry-cli"
 log_path="$basedir/$log_file"


### PR DESCRIPTION
This fixes [errors early in the installer run not getting reported correctly](https://github.com/getsentry/self-hosted/issues/1884) and [jq's docker build not using the proxy config correctly](https://github.com/getsentry/self-hosted/issues/1871)