### PR TITLE
Manually change 23.1.1 to nightly

### DIFF
--- a/.env
+++ b/.env
@@ -5,10 +5,10 @@ SENTRY_EVENT_RETENTION_DAYS=90
 SENTRY_BIND=9000
 # Set SENTRY_MAIL_HOST to a valid FQDN (host/domain name) to be able to send emails!
 # SENTRY_MAIL_HOST=example.com
-SENTRY_IMAGE=getsentry/sentry:23.1.1
-SNUBA_IMAGE=getsentry/snuba:23.1.1
-RELAY_IMAGE=getsentry/relay:23.1.1
-SYMBOLICATOR_IMAGE=getsentry/symbolicator:0.6.0
+SENTRY_IMAGE=getsentry/sentry:nightly
+SNUBA_IMAGE=getsentry/snuba:nightly
+RELAY_IMAGE=getsentry/relay:nightly
+SYMBOLICATOR_IMAGE=getsentry/symbolicator:nightly
 WAL2JSON_VERSION=latest
 HEALTHCHECK_INTERVAL=30s
 HEALTHCHECK_TIMEOUT=60s

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Self-Hosted Sentry 23.1.1
+# Self-Hosted Sentry nightly
 
 Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docker](https://www.docker.com/).
 


### PR DESCRIPTION
As a result of the 23.1.1 release, post release script errored out here:
https://github.com/getsentry/publish/actions/runs/4018136005

This manually changes the 23.1.1 image references to nightly.