### PR TITLE
Updates Redis to 6.2.10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
       test: echo stats | nc 127.0.0.1 11211
   redis:
     <<: *restart_policy
-    image: "redis:6.2.4-alpine"
+    image: "redis:6.2.10-alpine"
     healthcheck:
       <<: *healthcheck_defaults
       test: redis-cli ping


### PR DESCRIPTION
Redis patched two CVEs in release `6.2.9`. We would like to update the Sentry container to apply those fixes:

https://github.com/redis/redis/releases/tag/6.2.9

After that release, it looks like they pushed a bug fix in `6.2.10` so it probably makes sense to bump up to that.

If there's anything I can do to help test or evaluate this change, let me know.