### PR TITLE
Fix post-release.sh for `git pull`

### DIFF
--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -5,6 +5,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd $SCRIPT_DIR/..
 
 # Bring master back to nightlies after merge from release branch
-git checkout master && git pull
+git checkout master && git pull --rebase
 SYMBOLICATOR_VERSION=nightly ./scripts/bump-version.sh '' 'nightly'
 git diff --quiet || git commit -anm $'build: Set master version to nightly\n\n#skip-changelog' && git pull --rebase && git push


### PR DESCRIPTION
Adds a workaround for the error in https://github.com/getsentry/publish/actions/runs/4018136005

(not sure if this is fool-proof but it follows the suggestion in the output)




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
