### PR TITLE
ci: Add test for alerts to integration tests

### DIFF
--- a/_integration-test/alert_settings/settings.json
+++ b/_integration-test/alert_settings/settings.json
@@ -15,10 +15,11 @@
     ],
     "filters": [
         {
-            "id": "sentry.rules.filters.latest_release.LatestReleaseFilter"
+            "targetType": "Unassigned",
+            "id": "sentry.rules.filters.assigned_to.AssignedToFilter"
         }
     ],
-    "name": "test-alert-2",
+    "name": "test-alert",
     "frequency": 1440,
     "owner": "team:1"
 }

--- a/_integration-test/alert_settings/settings.json
+++ b/_integration-test/alert_settings/settings.json
@@ -10,18 +10,10 @@
     ],
     "conditions": [
         {
-            "interval": "1h",
-            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
-            "comparisonType": "count",
-            "value": "1"
+            "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
         }
     ],
-    "filters": [
-        {
-            "targetType": "Unassigned",
-            "id": "sentry.rules.filters.assigned_to.AssignedToFilter"
-        }
-    ],
+    "filters": [],
     "name": "test-alert",
     "frequency": 1440,
     "owner": "team:1"

--- a/_integration-test/alert_settings/settings.json
+++ b/_integration-test/alert_settings/settings.json
@@ -10,7 +10,10 @@
     ],
     "conditions": [
         {
-            "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
+            "interval": "1h",
+            "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+            "comparisonType": "count",
+            "value": "1"
         }
     ],
     "filters": [

--- a/_integration-test/alert_settings/settings.json
+++ b/_integration-test/alert_settings/settings.json
@@ -10,7 +10,7 @@
     ],
     "conditions": [
         {
-            "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
+            "id": "sentry.rules.conditions.every_event.EveryEventCondition"
         }
     ],
     "filters": [],

--- a/_integration-test/alert_settings/settings.json
+++ b/_integration-test/alert_settings/settings.json
@@ -1,0 +1,24 @@
+{
+    "actionMatch": "all",
+    "filterMatch": "any",
+    "actions": [
+        {
+            "targetType": "Team",
+            "id": "sentry.mail.actions.NotifyEmailAction",
+            "targetIdentifier": "1"
+        }
+    ],
+    "conditions": [
+        {
+            "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
+        }
+    ],
+    "filters": [
+        {
+            "id": "sentry.rules.filters.latest_release.LatestReleaseFilter"
+        }
+    ],
+    "name": "test-alert-2",
+    "frequency": 1440,
+    "owner": "team:1"
+}

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -154,7 +154,7 @@ SENTRY_AUTH_TOKEN=$(sentry_api_request "api/0/api-tokens/" -X POST --data "$SCOP
 sleep 10
 SENTRY_DSN=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].dsn.secret')
 # Then upload the symbols to that project (note the container mounts pwd to /work)
-SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym --log-level=debug
+SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym --log-level=debug --wait
 # Get public key for minidump upload
 PUBLIC_KEY=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].public')
 # Upload the minidump to be processed, this returns the event ID of the crash dump

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -152,8 +152,6 @@ SCOPES=$(jq -n -c --argjson scopes '["event:admin", "event:read", "member:read",
 SENTRY_AUTH_TOKEN=$(sentry_api_request "api/0/api-tokens/" -X POST --data "$SCOPES" | jq -r '.token')
 # wait to make sure the new token and keys have been generated
 sleep 10
-$dc stop post-process-forwarder-errors
-$dc stop post-process-forwarder-transactions
 SENTRY_DSN=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].dsn.secret')
 # Then upload the symbols to that project (note the container mounts pwd to /work)
 SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym --log-level=debug

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -150,6 +150,8 @@ echo "${_group}Test symbolicator works ..."
 # Set up sentry-cli command
 SCOPES=$(jq -n -c --argjson scopes '["event:admin", "event:read", "member:read", "org:read", "team:read", "project:read", "project:write", "team:write"]' '$ARGS.named')
 SENTRY_AUTH_TOKEN=$(sentry_api_request "api/0/api-tokens/" -X POST --data "$SCOPES" | jq -r '.token')
+# wait to make sure the new token and keys have been generated
+sleep 10
 SENTRY_DSN=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].dsn.secret')
 # Then upload the symbols to that project (note the container mounts pwd to /work)
 SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym --log-level=debug

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -128,7 +128,7 @@ echo "${_endgroup}"
 
 echo "${_group}Checking alert fired for internal project"
 echo "Checking that the event fired the alert"
-sentry_api_request "api/0/organizations/sentry/combined-rules/?expand=latestIncident&expand=lastTriggered&sort=incident_status&sort=date_triggered&team=myteams&team=unassigned" | jq '.[] | select(.name == "alert-test") | .lastTriggered'
+sentry_api_request "api/0/organizations/sentry/combined-rules/?expand=latestIncident&expand=lastTriggered&sort=incident_status&sort=date_triggered&team=myteams&team=unassigned" | jq '.[] | select(.name == "test-alert") | .lastTriggered'
 echo "Checking that we tried sending an email to the user"
 $dc logs smtp | grep -E -e "dnslookup for ${TEST_USER}"
 echo "${_endgroup}"

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -177,7 +177,7 @@ echo "${_endgroup}"
 
 echo "${_group}Checking alert fired for native project"
 echo "Checking that the event fired the alert"
-sentry_api_request "api/0/organizations/sentry/combined-rules/?expand=latestIncident&expand=lastTriggered&sort=incident_status&sort=date_triggered&team=myteams&team=unassigned" | jq -e '.[] | select(.name == "test-alert") | .lastTriggered'
+sentry_api_request "api/0/organizations/sentry/combined-rules/?expand=latestIncident&expand=lastTriggered&sort=incident_status&sort=date_triggered&team=myteams&team=unassigned" | jq -e '.[] | select(.name == "test-alert")'
 echo "Checking that we tried sending an email to the user"
 $dc logs smtp | grep -E -e "dnslookup for ${TEST_USER}"
 echo "${_endgroup}"

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -152,6 +152,8 @@ SCOPES=$(jq -n -c --argjson scopes '["event:admin", "event:read", "member:read",
 SENTRY_AUTH_TOKEN=$(sentry_api_request "api/0/api-tokens/" -X POST --data "$SCOPES" | jq -r '.token')
 # wait to make sure the new token and keys have been generated
 sleep 10
+$dc stop post-process-forwarder-errors
+$dc stop post-process-forwarder-transactions
 SENTRY_DSN=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].dsn.secret')
 # Then upload the symbols to that project (note the container mounts pwd to /work)
 SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym --log-level=debug
@@ -175,9 +177,9 @@ if [ -z "$EVENT_PROCESSED" ]; then
 fi
 echo "${_endgroup}"
 
-echo "${_group}Checking alert fired for internal project"
+echo "${_group}Checking alert fired for native project"
 echo "Checking that the event fired the alert"
-sentry_api_request "api/0/organizations/sentry/combined-rules/?expand=latestIncident&expand=lastTriggered&sort=incident_status&sort=date_triggered&team=myteams&team=unassigned" | jq '.[] | select(.name == "test-alert") | .lastTriggered'
+sentry_api_request "api/0/organizations/sentry/combined-rules/?expand=latestIncident&expand=lastTriggered&sort=incident_status&sort=date_triggered&team=myteams&team=unassigned" | jq -e '.[] | select(.name == "test-alert") | .lastTriggered'
 echo "Checking that we tried sending an email to the user"
 $dc logs smtp | grep -E -e "dnslookup for ${TEST_USER}"
 echo "${_endgroup}"

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -155,6 +155,9 @@ SENTRY_DSN=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[
 SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym
 # Get public key for minidump upload
 PUBLIC_KEY=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].public')
+# Turn off post-process snuba tasks to test failure
+$dc stop post-process-forwarder-errors
+$dc stop post-process-forwarder-transactions
 # Upload the minidump to be processed, this returns the event ID of the crash dump
 EVENT_ID=$(sentry_api_request "api/$NATIVE_PROJECT_ID/minidump/?sentry_key=$PUBLIC_KEY" -X POST -F 'upload_file_minidump=@windows.dmp' | sed 's/\-//g')
 # We have to wait for the item to be processed

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -152,7 +152,7 @@ SCOPES=$(jq -n -c --argjson scopes '["event:admin", "event:read", "member:read",
 SENTRY_AUTH_TOKEN=$(sentry_api_request "api/0/api-tokens/" -X POST --data "$SCOPES" | jq -r '.token')
 SENTRY_DSN=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].dsn.secret')
 # Then upload the symbols to that project (note the container mounts pwd to /work)
-SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym
+SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym --log-level=debug
 # Get public key for minidump upload
 PUBLIC_KEY=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].public')
 # Turn off post-process snuba tasks to test failure

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -155,9 +155,6 @@ SENTRY_DSN=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[
 SENTRY_URL="$SENTRY_TEST_HOST" sentry-cli upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --auth-token "$SENTRY_AUTH_TOKEN" windows.sym --log-level=debug
 # Get public key for minidump upload
 PUBLIC_KEY=$(sentry_api_request "api/0/projects/sentry/native/keys/" | jq -r '.[0].public')
-# Turn off post-process snuba tasks to test failure
-$dc stop post-process-forwarder-errors
-$dc stop post-process-forwarder-transactions
 # Upload the minidump to be processed, this returns the event ID of the crash dump
 EVENT_ID=$(sentry_api_request "api/$NATIVE_PROJECT_ID/minidump/?sentry_key=$PUBLIC_KEY" -X POST -F 'upload_file_minidump=@windows.dmp' | sed 's/\-//g')
 # We have to wait for the item to be processed

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -177,7 +177,7 @@ echo "${_endgroup}"
 
 echo "${_group}Checking alert fired for native project"
 echo "Checking that the event fired the alert"
-sentry_api_request "api/0/organizations/sentry/combined-rules/?expand=latestIncident&expand=lastTriggered&sort=incident_status&sort=date_triggered&team=myteams&team=unassigned" | jq -e '.[] | select(.name == "test-alert")'
+sentry_api_request "api/0/organizations/sentry/combined-rules/?expand=latestIncident&expand=lastTriggered&sort=incident_status&sort=date_triggered&team=myteams&team=unassigned" | jq -e '.[] | select(.name == "test-alert") | .lastTriggered'
 echo "Checking that we tried sending an email to the user"
 $dc logs smtp | grep -E -e "dnslookup for ${TEST_USER}"
 echo "${_endgroup}"

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -130,7 +130,7 @@ cat debug.log
 echo '------------------------------------------'
 echo "${_endgroup}"
 
-echo "${_group}Setting up alerts for the internal project"
+echo "${_group}Setting up alerts for a new project called native"
 # First set up a new project if it doesn't exist already
 SENTRY_ORG="${SENTRY_ORG:-sentry}"
 SENTRY_TEAM="${SENTRY_TEAM:-sentry}"
@@ -139,6 +139,9 @@ PROJECT_JSON=$(jq -n -c --arg name "$SENTRY_PROJECT" --arg slug "$SENTRY_PROJECT
 NATIVE_PROJECT_ID=$(sentry_api_request "api/0/teams/$SENTRY_ORG/$SENTRY_TEAM/projects/" | jq -r '.[]|select(.slug == "'"$SENTRY_PROJECT"'")|.id')
 if [ -z "${NATIVE_PROJECT_ID}" ]; then
   NATIVE_PROJECT_ID=$(sentry_api_request "api/0/teams/$SENTRY_ORG/$SENTRY_TEAM/projects/" -X POST --data "$PROJECT_JSON" | jq -r '. // null | .id')
+  if [ -z "${NATIVE_PROJECT_ID}" ]; then
+    sentry_api_request "api/0/teams/$SENTRY_ORG/$SENTRY_TEAM/projects/" -X POST --data "$PROJECT_JSON" | jq
+  fi
 fi
 sentry_api_request "api/0/projects/$SENTRY_TEAM/$SENTRY_PROJECT/rules/?duplicateRule=false&wizardV3=true" -X POST -d @./alert_settings/settings.json | jq '.actions'
 echo "${_endgroup}"

--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -78,7 +78,7 @@ releasefile.cache-path: '/data/releasefile-cache'
 #   secret_key: 'XXXXXXX'
 #   bucket_name: 's3-bucket-name'
 
-system.upload-url-prefix: 'http://web:9000'
+system.upload-url-prefix: 'http://localhost:9000'
 system.internal-url-prefix: 'http://web:9000'
 symbolicator.enabled: true
 symbolicator.options:

--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -78,6 +78,7 @@ releasefile.cache-path: '/data/releasefile-cache'
 #   secret_key: 'XXXXXXX'
 #   bucket_name: 's3-bucket-name'
 
+system.upload-url-prefix: 'http://web:9000'
 system.internal-url-prefix: 'http://web:9000'
 symbolicator.enabled: true
 symbolicator.options:


### PR DESCRIPTION
Alright, so I'm kicking myself a bit here... turns out it was way simpler to just use curl and jq rather than use playwright 🤦‍♂️😭.

I'm not totally sad I tried out playwright, as it gave good information on what we'd need for future perhaps more complicated tests (i.e. greater integration with frontend).

I initially was stuck on this route because I kept getting access denied issues, but it turns out if you keep your cookie around (like we do in the integration tests!) it doesn't block access. I'm not totally happy we're using an undocumented API (I plan to seek out if there is an ideal path for either making this API documented/stable in some way, or if we should be doing something else entirely), but I think this should be fine.

I decided to break this up into two parts: set the alert before other tests which create an event, then check that
a) the event has fired according to Sentry
b) the smtp server logs indicate we tried to look up the email of our test user (aka we tried to email them)

Should we change the test user email to some invalid domain? 🤔 

Fixes #1887 