### PR TITLE
Run lock issues/PRs only on getsentry

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   lock:
+    if: github.repository_owner == 'getsentry'
     runs-on: ubuntu-latest
     steps:
       - uses: getsentry/forked-action-lock-threads@master


### PR DESCRIPTION
There is no need to lock issues/PRs on forked repositories, also it faces this error lots of times:
`You have exceeded a secondary rate limit. Please wait a few minutes before you try again.`

Full list: https://github.com/aminvakil/self-hosted/actions/workflows/lock.yml

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
