### PR TITLE
Run close stale issues/PRs only on getsentry

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   stale:
+    if: github.repository_owner == 'getsentry'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@87c2b794b9b47a9bec68ae03c01aeb572ffebdb1


### PR DESCRIPTION
Continuing https://github.com/getsentry/self-hosted/pull/1966 thanks to @hubertdeng123 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
