### PR TITLE
Add proxy buffer size config to fix Bad Gateway

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -37,6 +37,9 @@ http {
 	proxy_http_version 1.1;
 	proxy_redirect off;
 	proxy_buffering off;
+	proxy_buffer_size          128k;
+	proxy_buffers              4 256k;
+	proxy_busy_buffers_size    256k;
 	proxy_next_upstream error timeout invalid_header http_502 http_503 non_idempotent;
 	proxy_next_upstream_tries 2;
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

I was unable to access the `All Events` tab when looking at an issue. The browser showed an infinite loading screen. Devtools revealed 502 Bad Gateway responses for `/api/0/issues/:id/attachments/`. When I looked at the nginx log I found the following error: `upstream sent too big header while reading response header from upstream`.
This PR fixes the bad gateway error and makes the `All Events` tab work again.

Doesn't seem to be the only place affected by this issue either. I checked the logs for this specific error using `docker logs sentry-self-hosted-nginx-1 2>&1 | grep 'upstream sent too big header while reading response header from upstream'` and found another instance of this issue on the `/api/0/organizations/:name/sessions/` endpoint, but no idea where this is used in the frontend.

resolves #1927

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
