### PR TITLE
feat(replays): add replays to self hosted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,6 +258,9 @@ services:
   snuba-transactions-consumer:
     <<: *snuba_defaults
     command: consumer --storage transactions --consumer-group transactions_group --auto-offset-reset=latest --max-batch-time-ms 750
+  snuba-replays-consumer:
+    <<: *snuba_defaults
+    command: consumer --storage replays --auto-offset-reset=latest --max-batch-time-ms 750
   snuba-replacer:
     <<: *snuba_defaults
     command: replacer --storage errors --auto-offset-reset=latest
@@ -322,6 +325,9 @@ services:
   ingest-consumer:
     <<: *sentry_defaults
     command: run ingest-consumer --all-consumer-types
+  ingest-replay-recordings:
+    <<: *sentry_defaults
+    command: run ingest-replay-recordings
   post-process-forwarder-errors:
       <<: *sentry_defaults
       # Increase `--commit-batch-size 1` below to deal with high-load environments.

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -3,7 +3,7 @@ echo "${_group}Creating additional Kafka topics ..."
 # NOTE: This step relies on `kafka` being available from the previous `snuba-api bootstrap` step
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
 EXISTING_KAFKA_TOPICS=$($dcr -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
-NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events"
+NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings"
 for topic in $NEEDED_KAFKA_TOPICS; do
   if ! echo "$EXISTING_KAFKA_TOPICS" | grep -wq $topic; then
     $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -258,6 +258,8 @@ SENTRY_FEATURES.update(
             "organizations:sso-saml2",
             "organizations:performance-view",
             "organizations:advanced-search",
+            "organizations:session-replay",
+            "organizations:session-replay-ui",
             "projects:custom-inbound-filters",
             "projects:data-forwarding",
             "projects:discard-groups",


### PR DESCRIPTION
- [x] Enables the replays feature flags by default for self hosted
- [x] Adds the consumers `ingest-replay-recordings` and `snuba-replays-consumer` to the docker-compose
- [x] Adds `ingest-replay-recordings` to kafka creation script (`ingest-replay-events` is automatically handled by the snuba creation script)
- [x] Adds an end-to-end test to confirm that a basic replay makes it through the system. This test checks two endpoints, one for clickhouse, and one for replay storage. 

also confirmed this works w/ self hosted by running a webpage with our SDK pointed at the DSN of the self hosted server, then seeing it in the UI.