### PR TITLE
Bump Kafka version to keep up with SaaS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
         target: /opt/sentry/
   zookeeper:
     <<: *restart_policy
-    image: "confluentinc/cp-zookeeper:5.5.0"
+    image: "confluentinc/cp-zookeeper:5.5.13"
     environment:
       ZOOKEEPER_CLIENT_PORT: "2181"
       CONFLUENT_SUPPORT_METRICS_ENABLE: "false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
         target: /opt/sentry/
   zookeeper:
     <<: *restart_policy
-    image: "confluentinc/cp-zookeeper:5.5.0"
+    image: "confluentinc/cp-zookeeper:5.5.7"
     environment:
       ZOOKEEPER_CLIENT_PORT: "2181"
       CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
@@ -170,7 +170,7 @@ services:
     depends_on:
       zookeeper:
         <<: *depends_on-healthy
-    image: "confluentinc/cp-kafka:5.5.13"
+    image: "confluentinc/cp-kafka:5.5.7"
     environment:
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
       KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
         target: /opt/sentry/
   zookeeper:
     <<: *restart_policy
-    image: "confluentinc/cp-zookeeper:5.5.13"
+    image: "confluentinc/cp-zookeeper:5.5.0"
     environment:
       ZOOKEEPER_CLIENT_PORT: "2181"
       CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
@@ -170,7 +170,7 @@ services:
     depends_on:
       zookeeper:
         <<: *depends_on-healthy
-    image: "confluentinc/cp-kafka:5.5.0"
+    image: "confluentinc/cp-kafka:5.5.13"
     environment:
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
       KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"


### PR DESCRIPTION
We're on a mix of 5.5.7 and 5.5.13 in Saas (and 6.2.0 in Sentry dev).