### PR TITLE
ref(snuba): Use snuba self-hosted settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ x-snuba-defaults: &snuba_defaults
       <<: *depends_on-healthy
   image: "$SNUBA_IMAGE"
   environment:
-    SNUBA_SETTINGS: docker
+    SNUBA_SETTINGS: self_hosted
     CLICKHOUSE_HOST: clickhouse
     DEFAULT_BROKERS: "kafka:9092"
     REDIS_HOST: redis


### PR DESCRIPTION
### Overview
A new [self-hosted settings](https://github.com/getsentry/snuba/pull/3889) file was added in snuba to house all self-hosted specific settings. This is required as a part of the [Dataset Readiness State](https://www.notion.so/sentry/Dataset-Readiness-States-da12e741fe024a7c8916c7b36b94ed8f?pvs=4#07f225050b964afd9d6d6d68e617043c) project. Currently, the new settings file is an exact copy of the existing `settings_docker.py`, therefore there are no expected changes.