### PR TITLE
Tweak permissioning of backup file in backup script to read/write for all users

### DIFF
--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -62,7 +62,8 @@ function clean() {
 }
 
 function backup() {
-  chmod +w $(pwd)/sentry
+  touch $(pwd)/sentry/backup.json
+  chmod 666 $(pwd)/sentry/backup.json
   docker-compose run -v $(pwd)/sentry:/sentry-data/backup --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export /sentry-data/backup/backup.json
 }
 


### PR DESCRIPTION
Saw this error in dogfood instance:
https://self-hosted.getsentry.net/organizations/self-hosted/issues/366/?project=3&query=is%3Aunresolved&referrer=issue-stream

So doing the same with our integration tests in `ensure-backup-restore-works.sh` to give all users read/write to the backup file so permission issues don't happen.