### PR TITLE
Support external sourcemaps bigger, than 1Mb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ x-sentry-defaults: &sentry_defaults
     # on the host system (or in the .env file)
     SENTRY_EVENT_RETENTION_DAYS:
     SENTRY_MAIL_HOST:
+    SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE:
   volumes:
     - "sentry-data:/data"
     - "./sentry:/etc/sentry"
@@ -107,10 +108,6 @@ services:
     <<: *restart_policy
     image: "memcached:1.6.9-alpine"
     command: ["-I", "${SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE:-1M}"]
-    environment:
-      # Leaving the value empty to just pass whatever is set
-      # on the host system (or in the .env file)
-      SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE:
     healthcheck:
       <<: *healthcheck_defaults
       # From: https://stackoverflow.com/a/31877626/5155484

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
   memcached:
     <<: *restart_policy
     image: "memcached:1.6.9-alpine"
-    command: "-I 25M"
+    command: ["-I", "25M"]
     healthcheck:
       <<: *healthcheck_defaults
       # From: https://stackoverflow.com/a/31877626/5155484

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,11 @@ services:
   memcached:
     <<: *restart_policy
     image: "memcached:1.6.9-alpine"
-    command: ["-I", "25M"]
+    command: ["-I", "${SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE:-1M}"]
+    environment:
+      # Leaving the value empty to just pass whatever is set
+      # on the host system (or in the .env file)
+      SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE:
     healthcheck:
       <<: *healthcheck_defaults
       # From: https://stackoverflow.com/a/31877626/5155484

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
   memcached:
     <<: *restart_policy
     image: "memcached:1.6.9-alpine"
+    command: "-I 25M"
     healthcheck:
       <<: *healthcheck_defaults
       # From: https://stackoverflow.com/a/31877626/5155484

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -107,6 +107,9 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
         "LOCATION": ["memcached:11211"],
         "TIMEOUT": 3600,
+        "OPTIONS": {
+            "server_max_value_length": 1024 * 1024 * 25,
+        },
     }
 }
 

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -6,8 +6,8 @@ from sentry.conf.server import *  # NOQA
 BYTE_MULTIPLIER = 1024
 UNITS = ("K", "M", "G")
 def unit_text_to_bytes(text):
-		unit = text[-1].upper()
-		power = UNITS.index(unit) + 1
+    unit = text[-1].upper()
+    power = UNITS.index(unit) + 1
     return float(text[:-1])*(BYTE_MULTIPLIER**power)
 
 

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -3,6 +3,15 @@
 
 from sentry.conf.server import *  # NOQA
 
+UNIT_SIZES={
+    "K": 1024,
+    "M": 1024**2,
+    "G": 1024**3,
+}
+def unit_text_to_bytes(text):
+    multiplier = UNIT_SIZES[text[-1]]
+    return float(text[:-1])*multiplier
+
 
 # Generously adapted from pynetlinux: https://github.com/rlisagor/pynetlinux/blob/e3f16978855c6649685f0c43d4c3fcf768427ae5/pynetlinux/ifconfig.py#L197-L223
 def get_internal_network():
@@ -108,7 +117,7 @@ CACHES = {
         "LOCATION": ["memcached:11211"],
         "TIMEOUT": 3600,
         "OPTIONS": {
-            "server_max_value_length": 1024 * 1024 * 25,
+            "server_max_value_length": unit_text_to_bytes(env("SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE", "1M")),
         },
     }
 }

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -3,14 +3,12 @@
 
 from sentry.conf.server import *  # NOQA
 
-UNIT_SIZES={
-    "K": 1024,
-    "M": 1024**2,
-    "G": 1024**3,
-}
+BYTE_MULTIPLIER = 1024
+UNITS = ("K", "M", "G")
 def unit_text_to_bytes(text):
-    multiplier = UNIT_SIZES[text[-1]]
-    return float(text[:-1])*multiplier
+		unit = text[-1].upper()
+		power = UNITS.index(unit) + 1
+    return float(text[:-1])*(BYTE_MULTIPLIER**power)
 
 
 # Generously adapted from pynetlinux: https://github.com/rlisagor/pynetlinux/blob/e3f16978855c6649685f0c43d4c3fcf768427ae5/pynetlinux/ifconfig.py#L197-L223


### PR DESCRIPTION
Self hosted sentry limited in sourcemap external size, which can fetch and cache to 1Mb. 

> Remote file too large for caching

This is because `memcached` the maximum size of a value you can store in is 1 megabyte by default. But this can be fixed by `-I` param.

This PR allow to fetch and cache external sourcemaps for sentry up to 25Mb.

![image](https://user-images.githubusercontent.com/98444/228269961-04ff4e4c-e420-4859-b162-402241f1c96b.png)


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
