### PR TITLE
bump postgres version from 9.6 to 14.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
         hard: 10032
   postgres:
     <<: *restart_policy
-    image: "postgres:9.6"
+    image: "postgres:14.7"
     healthcheck:
       <<: *healthcheck_defaults
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided


### PR DESCRIPTION


<!-- Describe your PR here. -->

Previous issue:
https://github.com/getsentry/self-hosted/issues/1097

List of CVEs associated with previous version of PostgresSQL:
https://www.postgresql.org/support/security/

No further security patches have been released since November 11, 2021 for version 9.6

PostgresSQL v14.7 seems to work on a fresh install of this docker compose setup. It would be nice if this update could happen sooner rather than later so my organization can continue using sentry. I might be willing/capable to re-submit another PR with an upgrade script or anything else needed to make this necessary database upgrade. Thanks




<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
