### PR TITLE
Change symbolicator to use CalVer for release

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,15 +4,12 @@ set -eu
 OLD_VERSION="$1"
 NEW_VERSION="$2"
 
-SYMBOLICATOR_VERSION=${SYMBOLICATOR_VERSION:-$(curl -s "https://api.github.com/repos/getsentry/symbolicator/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')}
 WAL2JSON_VERSION=${WAL2JSON_VERSION:-$(curl -s "https://api.github.com/repos/getsentry/wal2json/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')}
 
-sed -i -e "s/^SYMBOLICATOR_IMAGE=\([^:]\+\):.\+\$/SYMBOLICATOR_IMAGE=\1:$SYMBOLICATOR_VERSION/" .env
 sed -i -e "s/^WAL2JSON_VERSION=\([^:]\+\):.\+\$/WAL2JSON_VERSION=\1:$WAL2JSON_VERSION/" .env
-sed -i -e "s/^\(SENTRY\|SNUBA\|RELAY\)_IMAGE=\([^:]\+\):.\+\$/\1_IMAGE=\2:$NEW_VERSION/" .env
+sed -i -e "s/^\(SENTRY\|SNUBA\|RELAY\|SYMBOLICATOR\)_IMAGE=\([^:]\+\):.\+\$/\1_IMAGE=\2:$NEW_VERSION/" .env
 sed -i -e "s/^\# Self-Hosted Sentry .*/# Self-Hosted Sentry $NEW_VERSION/" README.md
 sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
 
 echo "New version: $NEW_VERSION"
-echo "New Symbolicator version: $SYMBOLICATOR_VERSION"
 echo "New wal2json version: $WAL2JSON_VERSION"

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -3,5 +3,5 @@ set -eu
 
 # Bring master back to nightlies after merge from release branch
 git checkout master && git pull --rebase
-SYMBOLICATOR_VERSION=nightly ./scripts/bump-version.sh '' 'nightly'
+./scripts/bump-version.sh '' 'nightly'
 git diff --quiet || git commit -anm $'build: Set master version to nightly\n\n#skip-changelog' && git pull --rebase && git push


### PR DESCRIPTION
change symbolicator to use the same version as relay/sentry/snuba

closes https://github.com/getsentry/self-hosted/issues/2073