### PR TITLE
Enable upstream keepalive

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -55,10 +55,12 @@ http {
 
 	upstream relay {
 		server relay:3000;
+		keepalive 2;
 	}
 
 	upstream sentry {
 		server web:9000;
+		keepalive 2;
 	}
 
 	server {


### PR DESCRIPTION
This enables keepalive connections for both upstream blocks, following the best practices as recommended by nginx:

https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives

> We recommend setting the parameter to twice the number of servers listed in the upstream{} block.

As there's only a single server in each block, we keep 2 idle connections.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
