### PR TITLE
Fix issue to run some queries and VACUUM command in database after update to PostgreSQL 14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,7 @@ services:
     <<: *restart_policy
     # Using the same postgres version as Sentry dev for consistency purposes
     image: "postgres:14.5"
+    shm_size: '4gb'
     healthcheck:
       <<: *healthcheck_defaults
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided


### PR DESCRIPTION
Fix issue to run some queries and VACUUM command in database after update to PostgreSQL 14

Without this changes some SQL command start return error: `ERROR: could not resize shared memory segment . . . : No space left on device`

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
