### PR TITLE
Fixed docker compose issue in backup/restore

### DIFF
--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -62,11 +62,11 @@ function clean() {
 function backup() {
   touch $(pwd)/sentry/backup.json
   chmod 666 $(pwd)/sentry/backup.json
-  docker-compose run -v $(pwd)/sentry:/sentry-data/backup --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export /sentry-data/backup/backup.json
+  $dc run -v $(pwd)/sentry:/sentry-data/backup --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export /sentry-data/backup/backup.json
 }
 
 function restore() {
-  docker-compose run --rm -T web import /etc/sentry/backup.json
+  $dc run --rm -T web import /etc/sentry/backup.json
 }
 
 # Needed variables to source error-handling script


### PR DESCRIPTION
The docker-compose command was hard coded in backup and restore routines. Replaced with `$dc` variable instead

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
