### PR TITLE
Uninstall Docker Compose v1 from CI so it's not used for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,8 @@ jobs:
           sudo mkdir -p "${{ matrix.compose_path }}"
           sudo curl -L https://github.com/docker/compose/releases/download/${{ matrix.compose_version }}/docker-compose-`uname -s`-`uname -m` -o "${{ matrix.compose_path }}/docker-compose"
           sudo chmod +x "${{ matrix.compose_path }}/docker-compose"
+          # Docker Compose v1 is installed here, remove it
+          sudo rm -f "/usr/local/bin/docker-compose"
 
       - name: Integration Test
         run: ./integration-test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,12 +64,12 @@ jobs:
           # Always remove `docker compose` support as that's the newer version
           # and comes installed by default nowadays.
           sudo rm -f "/usr/local/lib/docker/cli-plugins/docker-compose"
+          # Docker Compose v1 is installed here, remove it
+          sudo rm -f "/usr/local/bin/docker-compose"
           sudo rm -f "${{ matrix.compose_path }}/docker-compose"
           sudo mkdir -p "${{ matrix.compose_path }}"
           sudo curl -L https://github.com/docker/compose/releases/download/${{ matrix.compose_version }}/docker-compose-`uname -s`-`uname -m` -o "${{ matrix.compose_path }}/docker-compose"
           sudo chmod +x "${{ matrix.compose_path }}/docker-compose"
-          # Docker Compose v1 is installed here, remove it
-          sudo rm -f "/usr/local/bin/docker-compose"
 
       - name: Integration Test
         run: ./integration-test.sh

--- a/_integration-test/ensure-backup-restore-works.sh
+++ b/_integration-test/ensure-backup-restore-works.sh
@@ -11,8 +11,7 @@ echo "Creating backup..."
 touch $(pwd)/sentry/backup.json
 chmod 666 $(pwd)/sentry/backup.json
 # Command here matches exactly what we have in our docs https://develop.sentry.dev/self-hosted/backup/#backup
-docker-compose run -v $(pwd)/sentry:/sentry-data/backup --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export /sentry-data/backup/backup.json
-# Check to make sure there is content in the file
+source scripts/backup.sh # Check to make sure there is content in the file
 if [ ! -s "$(pwd)/sentry/backup.json" ]; then
   echo "Backup file is empty"
   exit 1
@@ -29,6 +28,6 @@ source install/set-up-and-migrate-database.sh
 docker-compose up -d
 
 echo "Importing backup..."
-docker-compose run --rm -T web import /etc/sentry/backup.json
+source scripts/restore.sh
 
 rm $(pwd)/sentry/backup.json

--- a/_integration-test/ensure-backup-restore-works.sh
+++ b/_integration-test/ensure-backup-restore-works.sh
@@ -11,23 +11,24 @@ echo "Creating backup..."
 touch $(pwd)/sentry/backup.json
 chmod 666 $(pwd)/sentry/backup.json
 # Command here matches exactly what we have in our docs https://develop.sentry.dev/self-hosted/backup/#backup
-source scripts/backup.sh # Check to make sure there is content in the file
+$dc run -v $(pwd)/sentry:/sentry-data/backup --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export /sentry-data/backup/backup.json
+# Check to make sure there is content in the file
 if [ ! -s "$(pwd)/sentry/backup.json" ]; then
   echo "Backup file is empty"
   exit 1
 fi
 
 # Bring postgres down and recreate the docker volume
-docker-compose stop postgres
+$dc stop postgres
 sleep 5
-docker-compose rm -f -v postgres
+$dc rm -f -v postgres
 docker volume rm sentry-postgres
 export SKIP_USER_CREATION=1
 source install/create-docker-volumes.sh
 source install/set-up-and-migrate-database.sh
-docker-compose up -d
+$dc up -d
 
 echo "Importing backup..."
-source scripts/restore.sh
+$dc run --rm -T web import /etc/sentry/backup.json
 
 rm $(pwd)/sentry/backup.json


### PR DESCRIPTION
This will uninstall docker compose v1.29 from CI so `docker-compose` cannot be used.

CI runs to indicate this is the case:
1. https://github.com/getsentry/self-hosted/actions/runs/4832862658/jobs/8612163711?pr=2114
1. https://github.com/getsentry/self-hosted/actions/runs/4832862658/jobs/8612163856?pr=2114