### PR TITLE
adding ulimits for zookeeper, kafka, and web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,10 @@ services:
       ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: "WARN"
       ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: "WARN"
       KAFKA_OPTS: "-Dzookeeper.4lw.commands.whitelist=ruok"
+    ulimits:
+      nofile:
+        soft: 4096
+        hard: 4096
     volumes:
       - "sentry-zookeeper:/var/lib/zookeeper/data"
       - "sentry-zookeeper-log:/var/lib/zookeeper/log"
@@ -186,6 +190,10 @@ services:
       KAFKA_LOG4J_LOGGERS: "kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN"
       KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
       KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
+    ulimits:
+      nofile:
+        soft: 4096
+        hard: 4096
     volumes:
       - "sentry-kafka:/var/lib/kafka/data"
       - "sentry-kafka-log:/var/lib/kafka/log"
@@ -296,6 +304,10 @@ services:
       - "sentry-symbolicator:/data"
   web:
     <<: *sentry_defaults
+    ulimits:
+      nofile:
+        soft: 4096
+        hard: 4096
     healthcheck:
       <<: *healthcheck_defaults
       test:


### PR DESCRIPTION
Without these zookeeper and kafka fail to start on some systems. While web will consume ~8G of RAM.

Fixes: #40617




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
