### PR TITLE
fix(suggested-fix): key should be 'key', not 'token'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ x-sentry-defaults: &sentry_defaults
     SENTRY_EVENT_RETENTION_DAYS:
     SENTRY_MAIL_HOST:
     SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE:
-    OPENAI_API_TOKEN:
+    OPENAI_API_KEY:
   volumes:
     - "sentry-data:/data"
     - "./sentry:/etc/sentry"


### PR DESCRIPTION
I was upgrading my Sentry instance to the latest version, then I spent like 15 minutes wondering on why the Suggested Fix feature I [made the PR of](https://github.com/getsentry/self-hosted/pull/2115) is gone. I thought the Sentry team changed the logic of that. It turns out I made a typo. 

This is how I feel right now:

![](https://media.tenor.com/ZFc20z8DItkAAAAC/facepalm-really.gif)

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
