### PR TITLE
ref(compose): Separate ingest consumers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,9 +332,15 @@ services:
   worker:
     <<: *sentry_defaults
     command: run worker
-  ingest-consumer:
+  events-consumer:
     <<: *sentry_defaults
-    command: run ingest-consumer --all-consumer-types
+    command: run ingest-consumer --consumer-type=events
+  attachments-consumer:
+    <<: *sentry_defaults
+    command: run ingest-consumer --consumer-type=attachments
+  transactions-consumer:
+    <<: *sentry_defaults
+    command: run ingest-consumer --consumer-type=transactions
   ingest-replay-recordings:
     <<: *sentry_defaults
     command: run ingest-replay-recordings


### PR DESCRIPTION
Ingest consumers will stop to support the `--all-consumer-types` option, and
instead will need to run separate instances for events, attachments, and
transactions.

See https://github.com/getsentry/sentry/pull/49957
