### PR TITLE
Fix bump version script

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -7,7 +7,7 @@ NEW_VERSION="$2"
 WAL2JSON_VERSION=${WAL2JSON_VERSION:-$(curl -s "https://api.github.com/repos/getsentry/wal2json/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')}
 
 sed -i -e "s/^WAL2JSON_VERSION=\([^:]\+\):.\+\$/WAL2JSON_VERSION=\1:$WAL2JSON_VERSION/" .env
-sed -i -e "s/^\(SENTRY\|SNUBA\|RELAY\|SYMBOLICATOR|VROOM\)_IMAGE=\([^:]\+\):.\+\$/\1_IMAGE=\2:$NEW_VERSION/" .env
+sed -i -e "s/^\(SENTRY\|SNUBA\|RELAY\|SYMBOLICATOR\|VROOM\)_IMAGE=\([^:]\+\):.\+\$/\1_IMAGE=\2:$NEW_VERSION/" .env
 sed -i -e "s/^\# Self-Hosted Sentry .*/# Self-Hosted Sentry $NEW_VERSION/" README.md
 sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
 


### PR DESCRIPTION
fixes the bump version script, resulted in certain images not getting tagged in the 23.6.0 release

https://github.com/getsentry/self-hosted/commit/dbded584377d50a2545a98de5d0d53d204b369a0