### PR TITLE
Release 23.6.1 cleanup

### DIFF
--- a/.env
+++ b/.env
@@ -5,11 +5,11 @@ SENTRY_EVENT_RETENTION_DAYS=90
 SENTRY_BIND=9000
 # Set SENTRY_MAIL_HOST to a valid FQDN (host/domain name) to be able to send emails!
 # SENTRY_MAIL_HOST=example.com
-SENTRY_IMAGE=getsentry/sentry:23.6.1
-SNUBA_IMAGE=getsentry/snuba:23.6.1
-RELAY_IMAGE=getsentry/relay:23.6.1
-SYMBOLICATOR_IMAGE=getsentry/symbolicator:23.6.1
-VROOM_IMAGE=getsentry/vroom:23.6.1
+SENTRY_IMAGE=getsentry/sentry:nightly
+SNUBA_IMAGE=getsentry/snuba:nightly
+RELAY_IMAGE=getsentry/relay:nightly
+SYMBOLICATOR_IMAGE=getsentry/symbolicator:nightly
+VROOM_IMAGE=getsentry/vroom:nightly
 WAL2JSON_VERSION=latest
 HEALTHCHECK_INTERVAL=30s
 HEALTHCHECK_TIMEOUT=60s

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Self-Hosted Sentry 23.6.1
+# Self-Hosted Sentry nightly
 
 Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docker](https://www.docker.com/).
 


### PR DESCRIPTION
closes https://github.com/getsentry/publish/issues/2383

The post release script didn't run successfully, so we'll need to manually perform these actions