### PR TITLE
Revert "ref: Move most consumers to unified consumer CLI"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -334,19 +334,19 @@ services:
     command: run worker
   events-consumer:
     <<: *sentry_defaults
-    command: run consumer ingest-events --consumer-group ingest-consumer
+    command: run ingest-consumer --consumer-type=events
   attachments-consumer:
     <<: *sentry_defaults
-    command: run consumer ingest-attachments --consumer-group ingest-consumer
+    command: run ingest-consumer --consumer-type=attachments
   transactions-consumer:
     <<: *sentry_defaults
-    command: run consumer ingest-transactions --consumer-group ingest-consumer
+    command: run ingest-consumer --consumer-type=transactions
   ingest-replay-recordings:
     <<: *sentry_defaults
-    command: run consumer ingest-replay-recordings --consumer-group ingest-replay-recordings
+    command: run ingest-replay-recordings
   ingest-profiles:
     <<: *sentry_defaults
-    command: run consumer ingest-profiles --consumer-group ingest-profiles --no-strict-offset-reset
+    command: run ingest-profiles --no-strict-offset-reset
   post-process-forwarder-errors:
     <<: *sentry_defaults
     command: run post-process-forwarder --entity errors
@@ -355,10 +355,10 @@ services:
     command: run post-process-forwarder --entity transactions --commit-log-topic=snuba-transactions-commit-log --synchronize-commit-group transactions_group
   subscription-consumer-events:
     <<: *sentry_defaults
-    command: run consumer events-subscription-results --consumer-group query-subscription-consumer
+    command: run query-subscription-consumer --topic events-subscription-results
   subscription-consumer-transactions:
     <<: *sentry_defaults
-    command: run consumer transactions-subscription-results --consumer-group query-subscription-consumer
+    command: run query-subscription-consumer --topic transactions-subscription-results
   sentry-cleanup:
     <<: *sentry_defaults
     image: sentry-cleanup-self-hosted-local


### PR DESCRIPTION
Reverts getsentry/self-hosted#2203

getting failures in sentry CI due to 
```
arroyo.errors.ConsumerError: KafkaError{code=UNKNOWN_TOPIC_OR_PART,val=3,str="Subscribed topic not available: profiles: Broker: Unknown topic or partition"}
```

Not sure exactly why, but tests are now extremely flaky so going to revert this for now