### PR TITLE
ref: Move all consumers to unified consumer CLI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,7 +346,7 @@ services:
     command: run consumer ingest-replay-recordings --consumer-group ingest-replay-recordings
   ingest-profiles:
     <<: *sentry_defaults
-    command: run consumer ingest-profiles --consumer-group ingest-profiles --no-strict-offset-reset
+    command: run consumer --no-strict-offset-reset ingest-profiles --consumer-group ingest-profiles
   post-process-forwarder-errors:
     <<: *sentry_defaults
     command: run post-process-forwarder --entity errors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -334,19 +334,19 @@ services:
     command: run worker
   events-consumer:
     <<: *sentry_defaults
-    command: run ingest-consumer --consumer-type=events
+    command: run consumer ingest-events --consumer-group ingest-consumer
   attachments-consumer:
     <<: *sentry_defaults
-    command: run ingest-consumer --consumer-type=attachments
+    command: run consumer ingest-attachments --consumer-group ingest-consumer
   transactions-consumer:
     <<: *sentry_defaults
-    command: run ingest-consumer --consumer-type=transactions
+    command: run consumer ingest-transactions --consumer-group ingest-consumer
   ingest-replay-recordings:
     <<: *sentry_defaults
-    command: run ingest-replay-recordings
+    command: run consumer ingest-replay-recordings --consumer-group ingest-replay-recordings
   ingest-profiles:
     <<: *sentry_defaults
-    command: run ingest-profiles --no-strict-offset-reset
+    command: run consumer ingest-profiles --consumer-group ingest-profiles --no-strict-offset-reset
   post-process-forwarder-errors:
     <<: *sentry_defaults
     command: run post-process-forwarder --entity errors
@@ -355,10 +355,10 @@ services:
     command: run post-process-forwarder --entity transactions --commit-log-topic=snuba-transactions-commit-log --synchronize-commit-group transactions_group
   subscription-consumer-events:
     <<: *sentry_defaults
-    command: run query-subscription-consumer --topic events-subscription-results
+    command: run consumer events-subscription-results --consumer-group query-subscription-consumer
   subscription-consumer-transactions:
     <<: *sentry_defaults
-    command: run query-subscription-consumer --topic transactions-subscription-results
+    command: run consumer transactions-subscription-results --consumer-group query-subscription-consumer
   sentry-cleanup:
     <<: *sentry_defaults
     image: sentry-cleanup-self-hosted-local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,7 +346,7 @@ services:
     command: run consumer ingest-replay-recordings --consumer-group ingest-replay-recordings
   ingest-profiles:
     <<: *sentry_defaults
-    command: run consumer ingest-profiles --consumer-group ingest-profiles --no-strict-offset-reset
+    command: run ingest-profiles --no-strict-offset-reset
   post-process-forwarder-errors:
     <<: *sentry_defaults
     command: run post-process-forwarder --entity errors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,7 +346,7 @@ services:
     command: run consumer ingest-replay-recordings --consumer-group ingest-replay-recordings
   ingest-profiles:
     <<: *sentry_defaults
-    command: run ingest-profiles --no-strict-offset-reset
+    command: run consumer ingest-profiles --consumer-group ingest-profiles --no-strict-offset-reset
   post-process-forwarder-errors:
     <<: *sentry_defaults
     command: run post-process-forwarder --entity errors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -352,7 +352,7 @@ services:
     command: run consumer post-process-forwarder-errors --consumer-group post-process-forwarder --synchronize-commit-log-topic=snuba-commit-log --synchronize-commit-group=snuba-consumers
   post-process-forwarder-transactions:
     <<: *sentry_defaults
-    command: run consumer post-process-forwarder-transactions --synchronize-commit-log-topic=snuba-transactions-commit-log --synchronize-commit-group transactions_group
+    command: run consumer post-process-forwarder-transactions --consumer-group post-process-forwarder --synchronize-commit-log-topic=snuba-transactions-commit-log --synchronize-commit-group transactions_group
   subscription-consumer-events:
     <<: *sentry_defaults
     command: run consumer events-subscription-results --consumer-group query-subscription-consumer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -349,10 +349,10 @@ services:
     command: run consumer --no-strict-offset-reset ingest-profiles --consumer-group ingest-profiles
   post-process-forwarder-errors:
     <<: *sentry_defaults
-    command: run post-process-forwarder --entity errors
+    command: run consumer post-process-forwarder-errors --consumer-group post-process-forwarder --synchronize-commit-log-topic=snuba-commit-log --synchronize-commit-group=snuba-consumers
   post-process-forwarder-transactions:
     <<: *sentry_defaults
-    command: run post-process-forwarder --entity transactions --commit-log-topic=snuba-transactions-commit-log --synchronize-commit-group transactions_group
+    command: run consumer post-process-forwarder-transactions --synchronize-commit-log-topic=snuba-transactions-commit-log --synchronize-commit-group transactions_group
   subscription-consumer-events:
     <<: *sentry_defaults
     command: run consumer events-subscription-results --consumer-group query-subscription-consumer

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ source install/update-docker-images.sh
 source install/build-docker-images.sh
 source install/install-wal2json.sh
 source install/bootstrap-snuba.sh
-source install/create-kafka-topics.sh
+# source install/create-kafka-topics.sh
 source install/upgrade-postgres.sh
 source install/set-up-and-migrate-database.sh
 source install/geoip.sh

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ source install/update-docker-images.sh
 source install/build-docker-images.sh
 source install/install-wal2json.sh
 source install/bootstrap-snuba.sh
-# source install/create-kafka-topics.sh
+source install/create-kafka-topics.sh
 source install/upgrade-postgres.sh
 source install/set-up-and-migrate-database.sh
 source install/geoip.sh

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -10,5 +10,6 @@ for topic in $NEEDED_KAFKA_TOPICS; do
     echo ""
   fi
 done
+sleep 10
 
 echo "${_endgroup}"

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -2,13 +2,10 @@ echo "${_group}Creating additional Kafka topics ..."
 
 # NOTE: This step relies on `kafka` being available from the previous `snuba-api bootstrap` step
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
-EXISTING_KAFKA_TOPICS=$($dcr -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
 NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles"
 for topic in $NEEDED_KAFKA_TOPICS; do
-  if ! echo "$EXISTING_KAFKA_TOPICS" | grep -wq $topic; then
-    $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092
-    echo ""
-  fi
+  $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092
+  echo ""
 done
 
 echo "${_endgroup}"

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -2,10 +2,13 @@ echo "${_group}Creating additional Kafka topics ..."
 
 # NOTE: This step relies on `kafka` being available from the previous `snuba-api bootstrap` step
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
+EXISTING_KAFKA_TOPICS=$($dcr -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
 NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles"
 for topic in $NEEDED_KAFKA_TOPICS; do
-  $dcr kafka kafka-topics --if-not-exists --create --topic $topic --bootstrap-server kafka:9092
-  echo ""
+  if ! echo "$EXISTING_KAFKA_TOPICS" | grep -wq $topic; then
+    $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092
+    echo ""
+  fi
 done
 
 echo "${_endgroup}"

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -4,7 +4,7 @@ echo "${_group}Creating additional Kafka topics ..."
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
 NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles"
 for topic in $NEEDED_KAFKA_TOPICS; do
-  $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092
+  $dcr kafka kafka-topics --if-not-exists --create --topic $topic --bootstrap-server kafka:9092
   echo ""
 done
 

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -10,6 +10,5 @@ for topic in $NEEDED_KAFKA_TOPICS; do
     echo ""
   fi
 done
-sleep 10
 
 echo "${_endgroup}"

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -5,7 +5,7 @@ echo "${_group}Creating additional Kafka topics ..."
 EXISTING_KAFKA_TOPICS=$($dcr -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
 NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles"
 for topic in $NEEDED_KAFKA_TOPICS; do
-  if ! echo "$EXISTING_KAFKA_TOPICS" | grep -wq $topic; then
+  if ! echo "$EXISTING_KAFKA_TOPICS" | grep -qE "(^| )$topic( |$)"; then
     $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092
     echo ""
   fi


### PR DESCRIPTION
Putting this up again since PR was reverted here: https://github.com/getsentry/self-hosted/pull/2223

Will need to investigate e2e test failures related to profiles topic not being found, resulting in CI being blocked on `getsentry/sentry`
