### PR TITLE
Fix #1684

### DIFF
--- a/install/detect-platform.sh
+++ b/install/detect-platform.sh
@@ -12,14 +12,12 @@ echo "${_group}Detecting Docker platform"
 # linux/amd64 by default due to virtualization.
 # See https://github.com/docker/cli/issues/3286 for the Docker bug.
 
-export DOCKER_EXISTS=$(command -v docker)
-export DOCKER_ARCH=$(docker info --format '{{.Architecture}}')
-
-if ! "$DOCKER_EXISTS" &>/dev/null; then
+if ! command -v docker &>/dev/null; then
   echo "FAIL: Could not find a \`docker\` binary on this system. Are you sure it's installed?"
   exit 1
 fi
 
+export DOCKER_ARCH=$(docker info --format '{{.Architecture}}')
 if [[ "$DOCKER_ARCH" = "x86_64" ]]; then
   export DOCKER_PLATFORM="linux/amd64"
   export CLICKHOUSE_IMAGE="yandex/clickhouse-server:20.3.9.70"

--- a/install/detect-platform.sh
+++ b/install/detect-platform.sh
@@ -12,7 +12,13 @@ echo "${_group}Detecting Docker platform"
 # linux/amd64 by default due to virtualization.
 # See https://github.com/docker/cli/issues/3286 for the Docker bug.
 
+export DOCKER_EXISTS=$(command -v docker &> /dev/null)
 export DOCKER_ARCH=$(docker info --format '{{.Architecture}}')
+
+if ! "$DOCKER_EXISTS" &> /dev/null; then
+  echo "FAIL: Could not find a \`docker\` binary on this system. Are you sure it's installed?"
+  exit 1
+fi
 
 if [[ "$DOCKER_ARCH" = "x86_64" ]]; then
   export DOCKER_PLATFORM="linux/amd64"

--- a/install/detect-platform.sh
+++ b/install/detect-platform.sh
@@ -12,7 +12,7 @@ echo "${_group}Detecting Docker platform"
 # linux/amd64 by default due to virtualization.
 # See https://github.com/docker/cli/issues/3286 for the Docker bug.
 
-export DOCKER_EXISTS=$(command -v docker &> /dev/null)
+export DOCKER_EXISTS=$(command -v docker)
 export DOCKER_ARCH=$(docker info --format '{{.Architecture}}')
 
 if ! "$DOCKER_EXISTS" &> /dev/null; then

--- a/install/detect-platform.sh
+++ b/install/detect-platform.sh
@@ -15,7 +15,7 @@ echo "${_group}Detecting Docker platform"
 export DOCKER_EXISTS=$(command -v docker)
 export DOCKER_ARCH=$(docker info --format '{{.Architecture}}')
 
-if ! "$DOCKER_EXISTS" &> /dev/null; then
+if ! "$DOCKER_EXISTS" &>/dev/null; then
   echo "FAIL: Could not find a \`docker\` binary on this system. Are you sure it's installed?"
   exit 1
 fi


### PR DESCRIPTION
Previous situation: we do most of our "check minimum requirements" work in the aptly named `check-minimum-requirements.sh`. This would be a natural home for the "check if `docker` even exists on this system" verification, but we actually run call into `docker info` to set some environment variables before this script gets run, in `detect-platforms.sh`. So I've adde the "does `docker` exist" check to that file, directly before we call `docker info`.