### PR TITLE
Update nginx to 1.25.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,7 +372,7 @@ services:
     <<: *restart_policy
     ports:
       - "$SENTRY_BIND:80/tcp"
-    image: "nginx:1.22.0-alpine"
+    image: "nginx:1.24.0-alpine"
     volumes:
       - type: bind
         read_only: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,7 +372,7 @@ services:
     <<: *restart_policy
     ports:
       - "$SENTRY_BIND:80/tcp"
-    image: "nginx:1.24.0-alpine"
+    image: "nginx:1.25.1-alpine"
     volumes:
       - type: bind
         read_only: true


### PR DESCRIPTION
LGTM the changelog: https://nginx.org/en/CHANGES-1.24
1.23 LGTM: https://nginx.org/en/CHANGES
and 1.22 only had a .1 with CVE fixes

1.25 is still a bit new, maybe we should wait before bumping: https://endoflife.date/nginx

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
