### PR TITLE
Update geoipupdate to 5.1.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -243,7 +243,7 @@ services:
       timeout: 10s
       retries: 30
   geoipupdate:
-    image: "maxmindinc/geoipupdate:v4.7.1"
+    image: "maxmindinc/geoipupdate:v5.1.1"
     # Override the entrypoint in order to avoid using envvars for config.
     # Futz with settings so we can keep mmdb and conf in same dir on host
     # (image looks for them in separate dirs by default).


### PR DESCRIPTION
I have read all changelogs between the two versions:
- https://github.com/maxmind/geoipupdate/releases
- https://github.com/maxmind/geoipupdate/releases?page=2

Since https://github.com/maxmind/geoipupdate/releases/tag/v4.8.0 there is two new ENVs to avoid overriding the entrypoint 
@chadwhitacre you did comment on #766 back in the day https://github.com/getsentry/self-hosted/pull/766/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3
Should we use ENVs now ?

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
