### PR TITLE
Remove nc -q option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
     healthcheck:
       <<: *healthcheck_defaults
       test:
-        ["CMD-SHELL", 'echo "ruok" | nc -w 2 -q 2 localhost 2181 | grep imok']
+        ["CMD-SHELL", 'echo "ruok" | nc -w 2 localhost 2181 | grep imok']
   kafka:
     <<: *restart_policy
     depends_on:


### PR DESCRIPTION
The nc -q option is failing for some users as seen [here](https://github.com/getsentry/self-hosted/issues/2260). Seems like -q does this from [docs](https://docs.oracle.com/cd/E86824_01/html/E54763/netcat-1.html) and seems safe to remove:
After receiving EOF on stdin, wait for specified number of seconds and quit.



