### PR TITLE
Resolve Safari Content-Disposition header bug

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,6 +43,9 @@ http {
 	proxy_next_upstream error timeout invalid_header http_502 http_503 non_idempotent;
 	proxy_next_upstream_tries 2;
 
+	# Must be removed to play nice with Safari, see the discussion in: getsentry/self-hosted#2285.
+	proxy_hide_header Content-Disposition;
+
 	# Remove the Connection header if the client sends it,
 	# it could be "close" to close a keepalive connection
 	proxy_set_header Connection '';


### PR DESCRIPTION
With release 23.7.0, the upstream sentry@23.7.0 upgraded Django to 3.2.20, a breaking change for that dependency. This introduced a number of bugs into self-hosted, including one where the Content-Disposition response header is now set by Django in a manner that is illegible to Safari, as documenting in https://code.djangoproject.com/ticket/31082.

This change modifies the default nginx config to override this header with the simpler `inline` setting, allowing Safari to properly decompress gzipped resources like CSS and Javascript bundles.

Fixes #2285