### PR TITLE
Ignore fixture-custom-ca-roots service in integration test

### DIFF
--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -150,8 +150,8 @@ echo "${_endgroup}"
 # Table formatting based on https://stackoverflow.com/a/39144364
 COMPOSE_PS_OUTPUT=$(docker compose ps --format json | jq -r \
   '.[] |
-   # we only care about running services. geoipupdate always exits, so we ignore it
-   select(.State != "running" and .Service != "geoipupdate") |
+   # we only care about running services. geoipupdate and fixture-custom-ca-roots always exits, so we ignore it
+   select(.State != "running" and .Service != "geoipupdate" and .Service != "fixture-custom-ca-roots") |
    # Filter to only show the service name and state
    with_entries(select(.key | in({"Service":1, "State":1})))
  ')


### PR DESCRIPTION
[CI is failing](https://github.com/getsentry/self-hosted/actions/runs/5754490765/job/15600711229) since it thinks that `fixture-custom-ca-roots` has errored out, when it fact it has just simply been removed as a part of testing. Not sure why this is happening all of the sudden, but this should be safe.

This is blocking 23.7.2 and even after changing the images in the .env to 23.7.1, CI still fails.

