### PR TITLE
change health check for kafka service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
       - "sentry-secrets:/etc/kafka/secrets"
     healthcheck:
       <<: *healthcheck_defaults
-      test: ["CMD-SHELL", "nc -z localhost 9092"]
+      test: ["CMD-SHELL", "/usr/bin/kafka-topics --bootstrap-server kafka:9092 --list"]
       interval: 10s
       timeout: 10s
       retries: 30


### PR DESCRIPTION
Checking kafka topics is a more proper way to check that kafka server is up and running, rather than just checking opened port. You should treat this as `pg_isready` command.

Before this patch, step with `bootstrap-snuba`, fails on topics creation with error:
```
Failed to create topic events (and many others)
Traceback (most recent call last):
  File "/usr/src/snuba/snuba/utils/manage_topics.py", line 31, in create_topics
    future.result()
  File "/usr/local/lib/python3.8/concurrent/futures/_base.py", line 444, in result
    return self.__get_result()
  File "/usr/local/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/usr/local/lib/python3.8/site-packages/confluent_kafka/admin/__init__.py", line 113, in _make_topics_result
    result = f.result()
  File "/usr/local/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/usr/local/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
cimpl.KafkaException: KafkaError{code=_TIMED_OUT,val=-185,str="Failed while waiting for response from broker: Local: Timed out"}
```

After this changes `bootstrap-snuba` waits for kafka and run smoothly.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
