### PR TITLE
Remove nginx content-disposition hack for safari

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,9 +43,6 @@ http {
 	proxy_next_upstream error timeout invalid_header http_502 http_503 non_idempotent;
 	proxy_next_upstream_tries 2;
 
-	# Must be removed to play nice with Safari, see the discussion in: getsentry/self-hosted#2285.
-	proxy_hide_header Content-Disposition;
-
 	# Remove the Connection header if the client sends it,
 	# it could be "close" to close a keepalive connection
 	proxy_set_header Connection '';


### PR DESCRIPTION
This is causing downloads to work unexpectedly.

https://github.com/getsentry/self-hosted/issues/2377