### PR TITLE
Update Redis container image to 6.2.13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       test: echo stats | nc 127.0.0.1 11211
   redis:
     <<: *restart_policy
-    image: "redis:6.2.12-alpine"
+    image: "redis:6.2.13-alpine"
     healthcheck:
       <<: *healthcheck_defaults
       test: redis-cli ping


### PR DESCRIPTION
Capturing some security fixes by updating to 6.2.13 for Redis [changelog](https://raw.githubusercontent.com/antirez/redis/6.2/00-RELEASENOTES).

This will remediate [CVE-2022-24834](https://redis.com/blog/security-notice-heap-overflow-vulnerabilties/).



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
