### PR TITLE
Switch geoipupdate image to ghcr.io

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,7 +244,7 @@ services:
       timeout: 10s
       retries: 30
   geoipupdate:
-    image: "maxmindinc/geoipupdate:v6.0.0"
+    image: "ghcr.io/maxmind/geoipupdate:v6.0.0"
     # Override the entrypoint in order to avoid using envvars for config.
     # Futz with settings so we can keep mmdb and conf in same dir on host
     # (image looks for them in separate dirs by default).


### PR DESCRIPTION
On https://hub.docker.com/r/maxmindinc/geoipupdate it's stated that newer versions of the image will be released on ghcr.io

This PR reflects that in the docker-compose.yml.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
