### PR TITLE
Update nginx.conf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -76,6 +76,7 @@ http {
 			proxy_pass http://sentry;
 		}
 		location /_static/ {
+			proxy_pass http://sentry;
 			proxy_hide_header Content-Disposition;
 		}
 	}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -75,5 +75,8 @@ http {
 		location / {
 			proxy_pass http://sentry;
 		}
+		location /_static/ {
+			proxy_hide_header Content-Disposition;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2285

Applies the same `proxy_hide_header Content-Disposition;`, but only to paths that start with `_static/` which should avoid the issue introduced previously with attachment downloads.
