### PR TITLE
deps: bump nginx to 1.25.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,8 +232,7 @@ services:
     # Override the entrypoint in order to avoid using envvars for config.
     # Futz with settings so we can keep mmdb and conf in same dir on host
     # (image looks for them in separate dirs by default).
-    entrypoint:
-      ["/usr/bin/geoipupdate", "-d", "/sentry", "-f", "/sentry/GeoIP.conf"]
+    entrypoint: ["/usr/bin/geoipupdate", "-d", "/sentry", "-f", "/sentry/GeoIP.conf"]
     volumes:
       - "./geoip:/sentry"
   snuba-api:
@@ -396,7 +395,7 @@ services:
     <<: *restart_policy
     ports:
       - "$SENTRY_BIND:80/tcp"
-    image: "nginx:1.25.1-alpine"
+    image: "nginx:1.25.2-alpine"
     volumes:
       - type: bind
         read_only: true


### PR DESCRIPTION
Bumps the nginx container to the latest available 1.25 version.

Address part of #2481 