### PR TITLE
configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0 # only security updates
+    reviewers:
+      - "@getsentry/open-source"
+      - "@getsentry/security"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    reviewers:
+      - "@getsentry/open-source"
+      - "@getsentry/security"


### PR DESCRIPTION
Configures dependabot to open PRs for security updates on our docker images.

I'm also including updates for our Github Actions, but if they end up too noisy -- we can re-assess. 