### PR TITLE
feat: provide a toggle to enable discord integration

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -119,3 +119,15 @@ transaction-events.force-disable-internal-project: true
 # slack.signing-secret: <signing secret>
 ## If legacy-app is True use verfication-token instead of signing-secret
 # slack.verification-token: <verification token>
+
+
+#######################
+# Discord Integration #
+#######################
+
+# Refer to https://develop.sentry.dev/integrations/discord/
+
+# discord.application-id: "<application id>"
+# discord.public-key: "<public key>"
+# discord.client-secret: "<client secret>"
+# discord.bot-token: "<bot token>"

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -306,6 +306,16 @@ GEOIP_PATH_MMDB = '/geoip/GeoLite2-City.mmdb'
 # BITBUCKET_CONSUMER_KEY = 'YOUR_BITBUCKET_CONSUMER_KEY'
 # BITBUCKET_CONSUMER_SECRET = 'YOUR_BITBUCKET_CONSUMER_SECRET'
 
+#######################
+# Discord Integration #
+#######################
+
+# Set the feature to be True if you'd like to enable Discord integration.
+# Refer to https://develop.sentry.dev/integrations/discord/
+SENTRY_FEATURES["organizations:integrations-discord"] = False
+SENTRY_FEATURES["organizations:integrations-discord-notifications"] = False
+SENTRY_FEATURES["organizations:integrations-discord-metric-alerts"] = False
+
 ##############################################
 # Suggested Fix Feature / OpenAI Integration #
 ##############################################

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -306,16 +306,6 @@ GEOIP_PATH_MMDB = '/geoip/GeoLite2-City.mmdb'
 # BITBUCKET_CONSUMER_KEY = 'YOUR_BITBUCKET_CONSUMER_KEY'
 # BITBUCKET_CONSUMER_SECRET = 'YOUR_BITBUCKET_CONSUMER_SECRET'
 
-#######################
-# Discord Integration #
-#######################
-
-# Set the feature to be True if you'd like to enable Discord integration.
-# Refer to https://develop.sentry.dev/integrations/discord/
-SENTRY_FEATURES["organizations:integrations-discord"] = False
-SENTRY_FEATURES["organizations:integrations-discord-notifications"] = False
-SENTRY_FEATURES["organizations:integrations-discord-metric-alerts"] = False
-
 ##############################################
 # Suggested Fix Feature / OpenAI Integration #
 ##############################################


### PR DESCRIPTION
Closes #2546 

I am aware that Discord integration hasn't gotten to GA yet. But I think it's usable enough and people are willing to use it.

If it's already at GA, we'd need to update this:

https://github.com/getsentry/develop/blob/f0bb60e09ca723e7f9be1ab1d5d3a3259d4a1ff7/src/docs/integrations/discord/index.mdx#L67-L75

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
