### PR TITLE
Enable Cron monitoring in self-hosted version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -368,6 +368,9 @@ services:
   ingest-profiles:
     <<: *sentry_defaults
     command: run consumer --no-strict-offset-reset ingest-profiles --consumer-group ingest-profiles
+  ingest-monitors:
+    <<: *sentry_defaults
+    command: run consumer --no-strict-offset-reset ingest-monitors --consumer-group ingest-monitors
   post-process-forwarder-errors:
     <<: *sentry_defaults
     command: run consumer post-process-forwarder-errors --consumer-group post-process-forwarder --synchronize-commit-log-topic=snuba-commit-log --synchronize-commit-group=snuba-consumers

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -3,7 +3,7 @@ echo "${_group}Creating additional Kafka topics ..."
 # NOTE: This step relies on `kafka` being available from the previous `snuba-api bootstrap` step
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
 EXISTING_KAFKA_TOPICS=$($dcr -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
-NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles ingest-occurrences ingest-metrics ingest-performance-metrics"
+NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles ingest-occurrences ingest-metrics ingest-performance-metrics ingest-monitors"
 for topic in $NEEDED_KAFKA_TOPICS; do
   if ! echo "$EXISTING_KAFKA_TOPICS" | grep -qE "(^| )$topic( |$)"; then
     $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -283,6 +283,7 @@ SENTRY_FEATURES.update(
             "organizations:dashboards-rh-widget",
             "organizations:metrics-extraction",
             "organizations:transaction-metrics-extraction",
+            "organizations:monitors",
             "projects:custom-inbound-filters",
             "projects:data-forwarding",
             "projects:discard-groups",


### PR DESCRIPTION
Sentry has had a Cron Monitoring feature in beta for a long time. Since Sentry is open-source, we can develop applications in our development with the self-hosted version before shipping them to the production environment without being worried about false alarms and spamming events. So, if it's possible, we would like to see this feature in the self-hosted too.  

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
