### PR TITLE
Patch for dev self-hosted environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ x-snuba-defaults: &snuba_defaults
 services:
   smtp:
     <<: *restart_policy
+    platform: linux/amd64
     image: tianon/exim4
     hostname: "${SENTRY_MAIL_HOST:-}"
     volumes:


### PR DESCRIPTION
Recently this error started appearing in dev environments on Apple silicon chips. 
```
▶ Setting up / migrating database ...
 smtp Pulling
no matching manifest for linux/arm64/v8 in the manifest list entries
Error in install/set-up-and-migrate-database.sh:13.
'$dcr web upgrade' exited with status 18
```

This is a workaround for that
