### PR TITLE
feat: Add sentry-admin.sh tool

### DIFF
--- a/_integration-test/ensure-backup-restore-works.sh
+++ b/_integration-test/ensure-backup-restore-works.sh
@@ -10,9 +10,7 @@ echo "Creating backup..."
 # to group and owner. Instead, try creating the empty file and then give everyone write access to the backup file
 touch $(pwd)/sentry/backup.json
 chmod 666 $(pwd)/sentry/backup.json
-# Command here matches exactly what we have in our docs https://develop.sentry.dev/self-hosted/backup/#backup
-$dc run -v $(pwd)/sentry:/sentry-data/backup --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export global /sentry-data/backup/backup.json
-# Check to make sure there is content in the file
+SENTRY_DOCKER_IO_DIR=$(pwd)/sentry /bin/bash $(pwd)/sentry-admin.sh export global /sentry-admin/backup.json
 if [ ! -s "$(pwd)/sentry/backup.json" ]; then
   echo "Backup file is empty"
   exit 1
@@ -33,6 +31,6 @@ source install/set-up-and-migrate-database.sh
 $dc up -d
 
 echo "Importing backup..."
-$dc run --rm -T web import global /etc/sentry/backup.json
+SENTRY_DOCKER_IO_DIR=$(pwd)/sentry /bin/bash $(pwd)/sentry-admin.sh import global /sentry-admin/backup.json
 
 rm $(pwd)/sentry/backup.json

--- a/_integration-test/ensure-sentry-admin-works.sh
+++ b/_integration-test/ensure-sentry-admin-works.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -ex
+
+source install/_lib.sh
+source install/dc-detect-version.sh
+
+echo "${_group}Test that sentry-admin works..."
+
+echo "Global help documentation..."
+
+global_help_doc=$(/bin/bash --help)
+if ! echo "$global_help_doc" | grep -q "^Usage: ./sentry-admin.sh"; then
+  echo "Assertion failed: Incorrect binary name in global help docs"
+  exit 1
+fi
+if ! echo "$global_help_doc" | grep -q "SENTRY_DOCKER_IO_DIR"; then
+  echo "Assertion failed: Missing SENTRY_DOCKER_IO_DIR global help doc"
+  exit 1
+fi
+
+echo "Command-specific help documentation..."
+
+command_help_doc=$(/bin/bash permissions --help)
+if ! echo "$command_help_doc" | grep -q "^Usage: ./sentry-admin.sh permissions"; then
+  echo "Assertion failed: Incorrect binary name in command-specific help docs"
+  exit 1
+fi
+
+echo "Exports via sentry-admin..."
+
+# Docker was giving me permissioning issues when trying to create this file and write to it even
+# after giving read + write access to group and owner. Instead, try creating the empty file and then
+# give everyone write access to the backup file
+touch $(pwd)/sentry-admin/backup.json
+chmod 666 $(pwd)/sentry-admin/backup.json
+
+# This command uses the `sentry-admin.sh` script to try an admin command.
+touch $(pwd)/sentry/admin/backup.json
+chmod -R 666 $(pwd)/sentry/admin/backup.json
+SENTRY_DOCKER_IO_DIR=$(pwd)/sentry-admin /bin/bash $(pwd)/sentry-admin.sh export global /sentry-admin/backup.json
+if [ ! -s "$(pwd)/sentry/backup.json" ]; then
+  echo "Assertion failed: Backup file is empty"
+  exit 1
+fi
+
+# Print backup.json contents
+echo "Backup file contents:\n\n"
+cat "$(pwd)/sentry-admin/backup.json"
+
+rm $(pwd)/sentry-admin/backup.json

--- a/_integration-test/ensure-sentry-admin-works.sh
+++ b/_integration-test/ensure-sentry-admin-works.sh
@@ -25,26 +25,3 @@ if ! echo "$command_help_doc" | grep -q "^Usage: ./sentry-admin.sh permissions";
   echo "Assertion failed: Incorrect binary name in command-specific help docs"
   exit 1
 fi
-
-echo "Exports via sentry-admin..."
-
-# Docker was giving me permissioning issues when trying to create this file and write to it even
-# after giving read + write access to group and owner. Instead, try creating the empty file and then
-# give everyone write access to the backup file
-touch $(pwd)/sentry-admin/backup.json
-chmod 666 $(pwd)/sentry-admin/backup.json
-
-# This command uses the `sentry-admin.sh` script to try an admin command.
-touch $(pwd)/sentry/admin/backup.json
-chmod -R 666 $(pwd)/sentry/admin/backup.json
-SENTRY_DOCKER_IO_DIR=$(pwd)/sentry-admin /bin/bash $(pwd)/sentry-admin.sh export global /sentry-admin/backup.json
-if [ ! -s "$(pwd)/sentry/backup.json" ]; then
-  echo "Assertion failed: Backup file is empty"
-  exit 1
-fi
-
-# Print backup.json contents
-echo "Backup file contents:\n\n"
-cat "$(pwd)/sentry-admin/backup.json"
-
-rm $(pwd)/sentry-admin/backup.json

--- a/sentry-admin.sh
+++ b/sentry-admin.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Detect docker and platform state.
+source install/dc-detect-version.sh
+source install/detect-platform.sh
+
+# Define the Docker volume mapping.
+VOLUME_MAPPING="${SENTRY_DOCKER_IO_DIR:-$HOME/.sentry/sentry-admin}:/sentry-admin"
+
+# Custom help text paragraphs
+HELP_TEXT_SUFFIX="
+All file paths are relative to the 'web' docker container, not the host environment. To pass files
+to/from the host system for commands that require it ('execfile', 'export', 'import', etc), you may
+specify a 'SENTRY_DOCKER_IO_DIR' environment variable to mount a volume for file IO operations into
+the host filesystem. The default value of 'SENTRY_DOCKER_IO_DIR' points to '~/.sentry/sentry-admin'
+on the host filesystem. Commands that write files should write them to the '/sentry-admin' in the
+'web' container (ex: './sentry-admin.sh export global /sentry-admin/my-export.json').
+"
+
+# Actual invocation that runs the command in the container.
+invocation() {
+  $dc run -v "$VOLUME_MAPPING" --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web "$@"
+}
+
+# Function to modify lines starting with `Usage: sentry` to say `Usage: ./sentry-admin.sh` instead.
+rename_sentry_bin_in_help_output() {
+  local output="$1"
+  local help_prefix="$2"
+  local usage_seen=false
+
+  output=$(invocation "$@")
+
+  echo -e "\n\n"
+
+  while IFS= read -r line; do
+    if [[ $line == "Usage: sentry"* ]] && [ "$usage_seen" = false ]; then
+      echo -e "\n\n"
+      echo "${line/sentry/./sentry-admin.sh}"
+      echo "$help_prefix"
+      usage_seen=true
+    else
+      if [[ $line == "Options:"* ]] && [ -n "$1" ]; then
+        echo "$help_prefix"
+      fi
+      echo "$line"
+    fi
+  done <<<"$output"
+}
+
+# Check for the user passing ONLY the '--help' argument - we'll add a special prefix to the output.
+if { [ "$1" = "help" ] || [ "$1" = "--help" ]; } && [ "$#" -eq 1 ]; then
+  rename_sentry_bin_in_help_output "$(invocation "$@")" "$HELP_TEXT_SUFFIX"
+  exit 0
+fi
+
+# Check for '--help' in other contexts.
+for arg in "$@"; do
+  if [ "$arg" = "--help" ]; then
+    rename_sentry_bin_in_help_output "$(invocation "$@")"
+    exit 0
+  fi
+done
+
+# Help has not been requested - go ahead and execute the command.
+echo -e "\n\n"
+invocation "$@"


### PR DESCRIPTION
`sentry-admin.sh` is just a bash wrapper around some admin commands that are already technically exposed in the `web` container, though a bit hard to find today. This command just forwards the `sentry` command-line administration tool out from the container onto the host machine, slightly editing the help docs to make it a bit easier to use in the process.