### PR TITLE
fix: set postgres shm_size to 256mb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
     entrypoint: /opt/sentry/postgres-entrypoint.sh
+    shm_size: "256mb"
     volumes:
       - "sentry-postgres:/var/lib/postgresql/data"
       - type: bind


### PR DESCRIPTION

update shared memory size for postrgres container to allow vacuum operations: https://github.com/docker-library/docs/blob/master/postgres/README.md#caveats

<img width="584" alt="Capture_could-not-resize-shared-memory-segment" src="https://github.com/getsentry/self-hosted/assets/45698566/9aa98b8c-b0c9-4f09-a07c-9707fe99888c">


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
