### PR TITLE
Nginx client request body is buffered to a temporary file

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -32,6 +32,7 @@ http {
 	server_names_hash_bucket_size 64;
 	types_hash_max_size 2048;
 	types_hash_bucket_size 64;
+	client_body_buffer_size 100m;
 	client_max_body_size 100m;
 
 	proxy_http_version 1.1;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -32,7 +32,7 @@ http {
 	server_names_hash_bucket_size 64;
 	types_hash_max_size 2048;
 	types_hash_bucket_size 64;
-	client_body_buffer_size 100m;
+	client_body_buffer_size 64k;
 	client_max_body_size 100m;
 
 	proxy_http_version 1.1;


### PR DESCRIPTION
This fixes warnings from nginx and creating temporary files on disk

```
[warn] 46#46: *133550 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000011816, client: 172.30.0.1, server: , request: "POST /api/53/envelope/?sentry_key=-&sentry_version=7&sentry_client=sentry.javascript.vue%2F7.80.0 HTTP/1.0", host: "-", referrer: "-/"
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
