### PR TITLE
Revert "Run CI every night (#1334)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ on:
       - "master"
       - "release/**"
   pull_request:
-  schedule:
-    - cron: "0 0,12 * * *"
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
<!-- Describe your PR here. -->

This reverts commit 48dd5eb144858b47c7631dffcd325021c4daa7a2 (#1334).

This has been added that time to capture a flake which happened randomly and as we talked about it then, I don't think it's necessary now.

I was going to limit it to run only on getsentry repository in #2681, but as I read more about the PR which it has been opened, I think it's time to disable it completely.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
