### PR TITLE
Enable crons

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -369,6 +369,9 @@ services:
   ingest-profiles:
     <<: *sentry_defaults
     command: run consumer --no-strict-offset-reset ingest-profiles --consumer-group ingest-profiles
+  ingest-monitors:
+    <<: *sentry_defaults
+    command: run consumer --no-strict-offset-reset ingest-monitors --consumer-group ingest-monitors
   post-process-forwarder-errors:
     <<: *sentry_defaults
     command: run consumer post-process-forwarder-errors --consumer-group post-process-forwarder --synchronize-commit-log-topic=snuba-commit-log --synchronize-commit-group=snuba-consumers

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -3,7 +3,7 @@ echo "${_group}Creating additional Kafka topics ..."
 # NOTE: This step relies on `kafka` being available from the previous `snuba-api bootstrap` step
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
 EXISTING_KAFKA_TOPICS=$($dcr -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
-NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles ingest-occurrences ingest-metrics ingest-performance-metrics"
+NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles ingest-occurrences ingest-metrics ingest-performance-metrics ingest-monitors"
 for topic in $NEEDED_KAFKA_TOPICS; do
   if ! echo "$EXISTING_KAFKA_TOPICS" | grep -qE "(^| )$topic( |$)"; then
     $dcr kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -278,6 +278,7 @@ SENTRY_FEATURES.update(
             "organizations:session-replay",
             "organizations:issue-platform",
             "organizations:profiling",
+            "organizations:monitors",
             "organizations:dashboards-mep",
             "organizations:mep-rollout-flag",
             "organizations:dashboards-rh-widget",


### PR DESCRIPTION
This PR does a few things to enable crons in self-hosted.
1. feature flag flipped on for crons
2. ingest consumer added for crons
3. crons kafka topic added

closes https://github.com/getsentry/self-hosted/issues/1993