### PR TITLE
fix: DB migration script

### DIFF
--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -10,7 +10,7 @@ until $dc exec postgres psql -U postgres -c "select 1" >/dev/null 2>&1 || [ $RET
 done
 indexes=$($dc exec postgres psql -qAt -U postgres -c "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'sentry_groupedmessage';")
 if [[ $indexes == *"sentry_groupedmessage_project_id_id_515aaa7e_uniq"* ]]; then
-  $dc postgres psql -qAt -U postgres -c "DROP INDEX sentry_groupedmessage_project_id_id_515aaa7e_uniq;"
+  $dc exec postgres psql -qAt -U postgres -c "DROP INDEX sentry_groupedmessage_project_id_id_515aaa7e_uniq;"
 fi
 
 if [[ -n "${CI:-}" || "${SKIP_USER_CREATION:-0}" == 1 ]]; then

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -2,7 +2,12 @@ echo "${_group}Setting up / migrating database ..."
 
 # Fixes https://github.com/getsentry/self-hosted/issues/2758, where a migration fails due to indexing issue
 $dc up -d postgres
-timeout 90s bash -c "until $dc exec postgres pg_isready ; do sleep 5 ; done"
+# Wait for postgres
+RETRIES=5
+until $dc exec postgres psql -U postgres -c "select 1" >/dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
+  echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
+  sleep 1
+done
 indexes=$($dc exec postgres psql -qAt -U postgres -c "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'sentry_groupedmessage';")
 if [[ $indexes == *"sentry_groupedmessage_project_id_id_515aaa7e_uniq"* ]]; then
   $dc postgres psql -qAt -U postgres -c "DROP INDEX sentry_groupedmessage_project_id_id_515aaa7e_uniq;"


### PR DESCRIPTION
This improves the logic to wait for postgres server to be up and running. It also fixes a typo 😬

It seems like using `pg_isready` in the install script was not a reliable way to wait for the postgres server to be up and ready to accept connections. So, I used a few lines that were previously working from the `upgrade-postgres.sh` script. Additionally, the `exec` command was missing when removing the specific db index causing issues.

Follow up to https://github.com/getsentry/self-hosted/issues/2758