### PR TITLE
Tweak postgres indexing fix

### DIFF
--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -8,10 +8,8 @@ until $dc exec postgres psql -U postgres -c "select 1" >/dev/null 2>&1 || [ $RET
   echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
   sleep 1
 done
-indexes=$($dc exec postgres psql -qAt -U postgres -c "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'sentry_groupedmessage';")
-if [[ $indexes == *"sentry_groupedmessage_project_id_id_515aaa7e_uniq"* ]]; then
-  $dc exec postgres psql -qAt -U postgres -c "DROP INDEX sentry_groupedmessage_project_id_id_515aaa7e_uniq;"
-fi
+$dc exec postgres psql -qAt -U postgres -c "ALTER TABLE sentry_groupedmessage DROP CONSTRAINT IF EXISTS sentry_groupedmessage_project_id_id_515aaa7e_uniq;"
+$dc exec postgres psql -qAt -U postgres -c "DROP INDEX IF EXISTS sentry_groupedmessage_project_id_id_515aaa7e_uniq;"
 
 if [[ -n "${CI:-}" || "${SKIP_USER_CREATION:-0}" == 1 ]]; then
   $dcr web upgrade --noinput

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -8,7 +8,7 @@ until $dc exec postgres psql -U postgres -c "select 1" >/dev/null 2>&1 || [ $RET
   echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
   sleep 1
 done
-$dc exec postgres psql -qAt -U postgres -c "ALTER TABLE sentry_groupedmessage DROP CONSTRAINT IF EXISTS sentry_groupedmessage_project_id_id_515aaa7e_uniq;"
+$dc exec postgres psql -qAt -U postgres -c "ALTER TABLE IF EXISTS sentry_groupedmessage DROP CONSTRAINT IF EXISTS sentry_groupedmessage_project_id_id_515aaa7e_uniq;"
 $dc exec postgres psql -qAt -U postgres -c "DROP INDEX IF EXISTS sentry_groupedmessage_project_id_id_515aaa7e_uniq;"
 
 if [[ -n "${CI:-}" || "${SKIP_USER_CREATION:-0}" == 1 ]]; then


### PR DESCRIPTION
Now fixes the groupedmessage indexing issue for a wider variety of users as reported in https://github.com/getsentry/self-hosted/issues/2780, particularly the one related to this error:
```
ERROR:  cannot drop index sentry_groupedmessage_project_id_id_515aaa7e_uniq because constraint sentry_groupedmessage_project_id_id_515aaa7e_uniq on table sentry_groupedmessage requires it
HINT:  You can drop constraint sentry_groupedmessage_project_id_id_515aaa7e_uniq on table sentry_groupedmessage instead.
```