### PR TITLE
Enable proxy buffering in nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -37,7 +37,6 @@ http {
 
 	proxy_http_version 1.1;
 	proxy_redirect off;
-	proxy_buffering off;
 	proxy_buffer_size          128k;
 	proxy_buffers              4 256k;
 	proxy_busy_buffers_size    256k;


### PR DESCRIPTION
Setting the proxy_buffering directive to “off” is a common mistake because it can cause performance issues and unexpected behavior in NGINX. When proxy buffering is disabled, NGINX receives a response from the proxied server and immediately sends it to the client without storing it in a buffer. This can cause problems if the response is large or if the connection between NGINX and the client is slow, because it can result in increased memory usage and potentially lead to request timeouts.

To avoid this mistake, it is recommended to always enable proxy buffering in NGINX.

Resolves https://github.com/getsentry/self-hosted/issues/2836

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
