### PR TITLE
Integration test improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,22 +86,12 @@ jobs:
           sudo chmod +x "${{ matrix.compose_path }}/docker-compose"
 
       - name: Install self-hosted
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          timeout_minutes: 10
-          retry_on: error
-          command: |
-            export REPORT_SELF_HOSTED_ISSUES=1
-            ./install.sh
+        run: |
+          export REPORT_SELF_HOSTED_ISSUES=1
+          ./install.sh
 
       - name: Integration Test
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          timeout_minutes: 25
-          retry_on: error
-          command: ./integration-test.sh --${{ matrix.test_type }}
+        run: ./integration-test.sh --${{ matrix.test_type }}
 
       - name: Inspect failure
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
             compose_path: "/usr/local/lib/docker/cli-plugins"
     env:
       COMPOSE_PROJECT_NAME: self-hosted-${{ strategy.job-index }}
+      SENTRY_DSN: https://5a620019b5124cbba230a9e62db9b825@o1.ingest.us.sentry.io/6627632
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,7 +92,7 @@ jobs:
           timeout_minutes: 10
           retry_on: error
           command: |
-            export REPORT_SELF_HOSTED_ISSUES=0
+            export REPORT_SELF_HOSTED_ISSUES=1
             ./install.sh
 
       - name: Integration Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
     env:
       COMPOSE_PROJECT_NAME: self-hosted-${{ strategy.job-index }}
       SENTRY_DSN: https://5a620019b5124cbba230a9e62db9b825@o1.ingest.us.sentry.io/6627632
+      REPORT_SELF_HOSTED_ISSUES: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -86,9 +87,7 @@ jobs:
           sudo chmod +x "${{ matrix.compose_path }}/docker-compose"
 
       - name: Install self-hosted
-        run: |
-          export REPORT_SELF_HOSTED_ISSUES=1
-          ./install.sh
+        run: ./install.sh
 
       - name: Integration Test
         run: ./integration-test.sh --${{ matrix.test_type }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,12 +59,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        test_type: ["initial-install", "customizations"]
+        compose_version: ["v2.0.1", "v2.7.0"]
         include:
           - compose_version: "v2.0.1"
             compose_path: "/usr/local/lib/docker/cli-plugins"
           - compose_version: "v2.7.0"
             compose_path: "/usr/local/lib/docker/cli-plugins"
-        test-group: ["initial-install", "customizations"]
     env:
       COMPOSE_PROJECT_NAME: self-hosted-${{ strategy.job-index }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,14 @@ jobs:
           sudo curl -L https://github.com/docker/compose/releases/download/${{ matrix.compose_version }}/docker-compose-`uname -s`-`uname -m` -o "${{ matrix.compose_path }}/docker-compose"
           sudo chmod +x "${{ matrix.compose_path }}/docker-compose"
 
+      - name: Install self-hosted
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          retry_on: error
+          command: ./install.sh
+
       - name: Integration Test
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           max_attempts: 3
           timeout_minutes: 25
           retry_on: error
-          command: ./integration-test.sh --${{ matrix.test-group }}
+          command: ./integration-test.sh --${{ matrix.test_type }}
 
       - name: Inspect failure
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,9 @@ jobs:
           max_attempts: 3
           timeout_minutes: 10
           retry_on: error
-          command: ./install.sh
+          command: |
+            export REPORT_SELF_HOSTED_ISSUES=0
+            ./install.sh
 
       - name: Integration Test
         uses: nick-fields/retry@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
             compose_path: "/usr/local/lib/docker/cli-plugins"
           - compose_version: "v2.7.0"
             compose_path: "/usr/local/lib/docker/cli-plugins"
+        test-group: ["initial-install", "customizations"]
     env:
       COMPOSE_PROJECT_NAME: self-hosted-${{ strategy.job-index }}
     steps:
@@ -83,7 +84,12 @@ jobs:
           sudo chmod +x "${{ matrix.compose_path }}/docker-compose"
 
       - name: Integration Test
-        run: ./integration-test.sh
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          timeout_minutes: 25
+          retry_on: error
+          command: ./integration-test.sh --${{ matrix.test-group }}
 
       - name: Inspect failure
         if: failure()

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -43,6 +43,7 @@ echo "${_group}Starting Sentry for tests ..."
 echo 'SENTRY_BEACON=False' >>$SENTRY_CONFIG_PY
 $dc up -d
 timeout 90 bash -c 'until $(curl -Isf -o /dev/null $SENTRY_TEST_HOST); do printf '.'; sleep 0.5; done'
+# DC exec here is faster, tests run on the slower side and using exec would provide a boost
 echo y | $dc exec web sentry createuser --force-update --superuser --email $TEST_USER --password $TEST_PASS
 printf "Waiting for Sentry to be up"
 echo ""

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -28,11 +28,12 @@ teardown() {
   DID_TEAR_DOWN=1
 
   if [ "$1" != "EXIT" ]; then
+    set +x
     error_msg="An error occurred, caught SIG$1 on line $2"
     echo "$error_msg"
     dsn="https://5a620019b5124cbba230a9e62db9b825@o1.ingest.us.sentry.io/6627632"
-    sentry_cli="docker run --rm -v /tmp:/work -e SENTRY_DSN=$dsn getsentry/sentry-cli"
-    $sentry_cli send-event -m "$error_msg" --logfile "$log_file"
+    local sentry_cli="docker run --rm -v $(pwd):/work -e SENTRY_DSN=$dsn getsentry/sentry-cli"
+    $sentry_cli send-event -m "$error_msg" --logfile $log_file
   fi
 
   echo "Tearing down ..."

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -1,41 +1,13 @@
 #!/usr/bin/env bash
 set -ex
 
-source install/_lib.sh
-source install/dc-detect-version.sh
-
 echo "${_group}Setting up variables and helpers ..."
 export SENTRY_TEST_HOST="${SENTRY_TEST_HOST:-http://localhost:9000}"
 TEST_USER='test@example.com'
 TEST_PASS='test123TEST'
 COOKIE_FILE=$(mktemp)
 
-# Courtesy of https://stackoverflow.com/a/2183063/90297
-trap_with_arg() {
-  func="$1"
-  shift
-  for sig; do
-    trap "$func $sig "'$LINENO' "$sig"
-  done
-}
-
-DID_TEAR_DOWN=0
-# the teardown function will be the exit point
-teardown() {
-  if [ "$DID_TEAR_DOWN" -eq 1 ]; then
-    return 0
-  fi
-  DID_TEAR_DOWN=1
-
-  if [ "$1" != "EXIT" ]; then
-    echo "An error occurred, caught SIG$1 on line $2"
-  fi
-
-  echo "Tearing down ..."
-  rm $COOKIE_FILE
-  echo "Done."
-}
-trap_with_arg teardown ERR INT TERM EXIT
+trap_with_arg cleanup ERR INT TERM EXIT
 echo "${_endgroup}"
 
 echo "${_group}Starting Sentry for tests ..."

--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -28,12 +28,7 @@ teardown() {
   DID_TEAR_DOWN=1
 
   if [ "$1" != "EXIT" ]; then
-    set +x
-    error_msg="An error occurred, caught SIG$1 on line $2"
-    echo "$error_msg"
-    dsn="https://5a620019b5124cbba230a9e62db9b825@o1.ingest.us.sentry.io/6627632"
-    local sentry_cli="docker run --rm -v $(pwd):/work -e SENTRY_DSN=$dsn getsentry/sentry-cli"
-    $sentry_cli send-event -m "$error_msg" --logfile $log_file
+    echo "An error occurred, caught SIG$1 on line $2"
   fi
 
   echo "Tearing down ..."

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -1,13 +1,13 @@
 echo "${_group}Setting up error handling ..."
 
-export SENTRY_DSN='https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
-export SENTRY_ORG=self-hosted
-export SENTRY_PROJECT=installer
+if [ -z "${SENTRY_DSN:-}" ]; then
+  export SENTRY_DSN='https://19555c489ded4769978daae92f2346ca@self-hosted.getsentry.net/3'
+fi
 
 $dbuild -t sentry-self-hosted-jq-local --platform="$DOCKER_PLATFORM" jq
 
 jq="docker run --rm -i sentry-self-hosted-jq-local"
-sentry_cli="docker run --rm -v /tmp:/work -e SENTRY_ORG=$SENTRY_ORG -e SENTRY_PROJECT=$SENTRY_PROJECT -e SENTRY_DSN=$SENTRY_DSN getsentry/sentry-cli"
+sentry_cli="docker run --rm -v /tmp:/work -e SENTRY_DSN=$SENTRY_DSN getsentry/sentry-cli"
 
 send_envelope() {
   # Send envelope

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -10,13 +10,11 @@ test_option="$1"
 
 if [[ "$test_option" == "--initial-install" ]]; then
   echo "Testing initial install"
-  ./install.sh
   _integration-test/run.sh
   _integration-test/ensure-customizations-not-present.sh
   _integration-test/ensure-backup-restore-works.sh
 elif [[ "$test_option" == "--customizations" ]]; then
   echo "Testing customizations"
-  ./install.sh
   source install/dc-detect-version.sh
   $dc up -d
   echo "Making customizations"

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -6,24 +6,32 @@ rm -f sentry/enhance-image.sh
 rm -f sentry/requirements.txt
 export REPORT_SELF_HOSTED_ISSUES=0
 
-echo "Testing initial install"
-./install.sh
-_integration-test/run.sh
-_integration-test/ensure-customizations-not-present.sh
-_integration-test/ensure-backup-restore-works.sh
+test_option="$1"
 
-echo "Make customizations"
-cat <<EOT >sentry/enhance-image.sh
+if [[ "$test_option" == "--initial-install" ]]; then
+  echo "Testing initial install"
+  ./install.sh
+  _integration-test/run.sh
+  _integration-test/ensure-customizations-not-present.sh
+  _integration-test/ensure-backup-restore-works.sh
+elif [[ "$test_option" == "--customizations" ]]; then
+  echo "Testing customizations"
+  ./install.sh
+  source install/dc-detect-version.sh
+  $dc up -d
+  echo "Making customizations"
+  cat <<EOT >sentry/enhance-image.sh
 #!/bin/bash
 touch /created-by-enhance-image
 apt-get update
 apt-get install -y gcc libsasl2-dev python-dev libldap2-dev libssl-dev
 EOT
-chmod +x sentry/enhance-image.sh
-printf "python-ldap" >sentry/requirements.txt
+  chmod +x sentry/enhance-image.sh
+  printf "python-ldap" >sentry/requirements.txt
 
-echo "Testing in-place upgrade and customizations"
-./install.sh --minimize-downtime
-_integration-test/run.sh
-_integration-test/ensure-customizations-work.sh
-_integration-test/ensure-backup-restore-works.sh
+  echo "Testing in-place upgrade and customizations"
+  ./install.sh --minimize-downtime
+  _integration-test/run.sh
+  _integration-test/ensure-customizations-work.sh
+  _integration-test/ensure-backup-restore-works.sh
+fi

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-# This file runs in https://github.com/getsentry/sentry/blob/fe4795f5eae9e0d7c33e0ecb736c9d1369535eca/docker/cloudbuild.yaml#L59
+export MINIMIZE_DOWNTIME=0
+export REPORT_SELF_HOSTED_ISSUES=1
 
-_integration-test/run.sh
+# This file runs in https://github.com/getsentry/sentry/blob/fe4795f5eae9e0d7c33e0ecb736c9d1369535eca/docker/cloudbuild.yaml#L59
+source install/_lib.sh
+source install/detect-platform.sh
+source install/dc-detect-version.sh
+source install/error-handling.sh
+source _integration-test/run.sh


### PR DESCRIPTION
This PR adds a couple of improvements to our integration test pipeline.

1. Parallelizes some tests, runtime was 23+ minutes. Now this is decreased to <18 minutes
2. Reports failures to Sentry project

In order to report flakes, I wanted to cut down the time it takes to actually run these tests. Given that with 20 min tests, it could take an hour if the tests flake twice.