### PR TITLE
feat(vroom): Allow to customize vroom's environment variables in a different file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -440,13 +440,8 @@ services:
     <<: *restart_policy
     image: "$VROOM_IMAGE"
     environment:
-      SENTRY_KAFKA_BROKERS_PROFILING: "kafka:9092"
-      SENTRY_KAFKA_BROKERS_OCCURRENCES: "kafka:9092"
-      SENTRY_BUCKET_PROFILES: file://localhost//var/lib/sentry-profiles
-      SENTRY_SNUBA_HOST: "http://snuba-api:1218"
     env_file:
-      - path: ./vroom.env
-        required: false
+      - ./vroom.env
     volumes:
       - sentry-vroom:/var/lib/sentry-profiles
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -444,6 +444,9 @@ services:
       SENTRY_KAFKA_BROKERS_OCCURRENCES: "kafka:9092"
       SENTRY_BUCKET_PROFILES: file://localhost//var/lib/sentry-profiles
       SENTRY_SNUBA_HOST: "http://snuba-api:1218"
+    env_file:
+      - path: ./vroom.env
+        required: false
     volumes:
       - sentry-vroom:/var/lib/sentry-profiles
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -439,7 +439,6 @@ services:
   vroom:
     <<: *restart_policy
     image: "$VROOM_IMAGE"
-    environment:
     env_file:
       - ./vroom.env
     volumes:

--- a/vroom.env
+++ b/vroom.env
@@ -1,0 +1,4 @@
+SENTRY_KAFKA_BROKERS_PROFILING="kafka:9092"
+SENTRY_KAFKA_BROKERS_OCCURRENCES="kafka:9092"
+SENTRY_BUCKET_PROFILES=file://localhost//var/lib/sentry-profiles
+SENTRY_SNUBA_HOST="http://snuba-api:1218"


### PR DESCRIPTION
We've had a request to be able to customize `vroom`'s configuration (which is using environment variables) via a file. 

Instead of implementing a file based configuration, we can simplify this by loading from a different environment file dedicated to `vroom`.