### PR TITLE
fix(spans): Adds organizations:standalone-span-ingestion flag to default config

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -307,6 +307,7 @@ SENTRY_FEATURES.update(
             "organizations:performance-screens-view",
             "organizations:mobile-ttid-ttfd-contribution",
             "organizations:starfish-mobile-appstart",
+            "organizations:standalone-span-ingestion",
         )  # starfish related flags
     }
 )


### PR DESCRIPTION
Fixes standalone span ingestion not working on relay by adding missing organizations:standalone-span-ingestion flag to default config.