### PR TITLE
Add example to docker compose version in problem report

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -36,6 +36,7 @@ body:
       placeholder: 2.6.0 ← should look like this (docker compose version)
       description: |
         What version of docker compose are you using to run self-hosted?
+        e.g: (docker compose version)
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Adds an example to get the version of docker compose. 

Since the command to get the version of **Docker** is `docker --version` you would expect the command for **Docker Compose** to be `docker compose --version` but for whatever reason it's not, so people probably waste time trying to figure out what the proper command is.



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
