### PR TITLE
Mdtro/bump postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
   postgres:
     <<: *restart_policy
     # Using the same postgres version as Sentry dev for consistency purposes
-    image: "postgres:14.5"
+    image: "postgres:14.11-alpine"
     healthcheck:
       <<: *healthcheck_defaults
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided


### PR DESCRIPTION
The `postgres:14.5` image has known vulnerabilities. This bumps us to `14.11-alpine` where the vulnerabilities are patched and moves us to a lightweight container. 

Sentry developer environments are currently on the alpine version of 14.9, but [should be on 14.11 soon.](https://github.com/getsentry/image-mirror/pull/20)