### PR TITLE
fix: use nginx realip module

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,11 +43,17 @@ http {
 	proxy_next_upstream error timeout invalid_header http_502 http_503 non_idempotent;
 	proxy_next_upstream_tries 2;
 
+	set_real_ip_from 10.0.0.0/8;
+	set_real_ip_from 172.16.0.0/12;
+	set_real_ip_from 192.168.0.0/16;
+	real_ip_header X-Forwarded-For;
+	real_ip_recursive on;
+
 	# Remove the Connection header if the client sends it,
 	# it could be "close" to close a keepalive connection
 	proxy_set_header Connection '';
 	proxy_set_header Host $host;
-	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	proxy_set_header X-Forwarded-For $remote_addr;
 	proxy_set_header X-Forwarded-Proto $scheme;
 	proxy_set_header X-Request-Id $request_id;
 	proxy_read_timeout 30s;


### PR DESCRIPTION
By default, Sentry gets the client's IP address from the `X-Forwarded-For` header:
https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L3080

However, this header can be spoofed. The more correct approach adhering to standard is suggested in https://github.com/getsentry/sentry/pull/68884
However, before going forward with it, we need to make sure that we are not breaking self-hosted installations.

This PR makes sure that the `X-Forwarded-For` header that is sent along the request to the `sentry` container, contains the real IP address of the client, and it's the only one, no other values in the list.

We do so by using [nginx realip module](https://nginx.org/en/docs/http/ngx_http_realip_module.html) in the `nginx` container of self-hosted installation:
1. if there is an `X-Forwarded-For` header coming from internal subnets (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), then we trust it and use the rightmost IP address that does not belong to the said subnets. E.g in the case of `SPOOFED_IP, MY_REAL_IP, 172.17.0.0` it will be `MY_REAL_IP`;
2. if there is an `X-Forwarded-For` header coming from the other untrusted subnet, then the rightmost (untrustworthy) value will be used;
3. if there is no `X-Forwarded-For` header in a request to the `nginx` container, then the IP address of the connection will be used (as usual).

We recommend to use an external load balancer (such as nginx) in addition to self-hosted docker-compose: https://develop.sentry.dev/self-hosted/#productionalizing
Usually, a load balancer sends `X-Forwarded-For` request header so it will always be the case 1 (from above list), and `sentry` container will get the correct client's IP address.