### PR TITLE
Sampling: Run e2e tests every 5 minutes

### DIFF
--- a/.github/workflows/sample-test-runs.yml
+++ b/.github/workflows/sample-test-runs.yml
@@ -1,0 +1,23 @@
+name: Test
+on:
+  schedule:
+    # kick off a job every 5 minutes
+    - cron: "*/5 * * * *"
+defaults:
+  run:
+    shell: bash
+jobs:
+  e2e-test:
+    if: github.repository_owner == 'getsentry'
+    runs-on: ubuntu-22.04
+    name: "Sentry self-hosted end-to-end tests"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: self-hosted
+
+      - name: End to end tests
+        uses: getsentry/action-self-hosted-e2e-tests@main
+        with:
+          project_name: self-hosted


### PR DESCRIPTION
let's keep this on during the workday for sampling purposes, run e2e tests 100+ times before getting rid of this workflow

I think then we can use something like https://github.com/fchimpan/gh-workflow-stats for some useful stats