### PR TITLE
feat(performance): add INP and Request feature flag

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -309,6 +309,8 @@ SENTRY_FEATURES.update(
             "organizations:starfish-mobile-appstart",
             "organizations:standalone-span-ingestion",
             "organizations:spans-first-ui",
+            "organizations:performance-http-view",
+            "organizations:performance-vitals-inp",
         )  # starfish related flags
     }
 )


### PR DESCRIPTION
Solves INP result not showing up on self-hosted. Also add the "Requests" page under "Performance" tab.

Linked issues: #2970

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
