### PR TITLE
feat(feedback): create kafka topic and consumer for ingest-feedback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,8 +177,7 @@ services:
       - "sentry-secrets:/etc/zookeeper/secrets"
     healthcheck:
       <<: *healthcheck_defaults
-      test:
-        ["CMD-SHELL", 'echo "ruok" | nc -w 2 localhost 2181 | grep imok']
+      test: ["CMD-SHELL", 'echo "ruok" | nc -w 2 localhost 2181 | grep imok']
   kafka:
     <<: *restart_policy
     depends_on:
@@ -250,7 +249,8 @@ services:
     # Override the entrypoint in order to avoid using envvars for config.
     # Futz with settings so we can keep mmdb and conf in same dir on host
     # (image looks for them in separate dirs by default).
-    entrypoint: ["/usr/bin/geoipupdate", "-d", "/sentry", "-f", "/sentry/GeoIP.conf"]
+    entrypoint:
+      ["/usr/bin/geoipupdate", "-d", "/sentry", "-f", "/sentry/GeoIP.conf"]
     volumes:
       - "./geoip:/sentry"
   snuba-api:
@@ -363,6 +363,9 @@ services:
   transactions-consumer:
     <<: *sentry_defaults
     command: run consumer ingest-transactions --consumer-group ingest-consumer
+  feedback-events-consumer:
+    <<: *sentry_defaults
+    command: run consumer ingest-feedback-events --consumer-group ingest-feedback-events
   metrics-consumer:
     <<: *sentry_defaults
     command: run consumer ingest-metrics --consumer-group metrics-consumer

--- a/install/create-kafka-topics.sh
+++ b/install/create-kafka-topics.sh
@@ -14,7 +14,7 @@ done
 
 # XXX(BYK): We cannot use auto.create.topics as Confluence and Apache hates it now (and makes it very hard to enable)
 EXISTING_KAFKA_TOPICS=$($dc exec -T kafka kafka-topics --list --bootstrap-server kafka:9092 2>/dev/null)
-NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles ingest-occurrences ingest-metrics ingest-performance-metrics ingest-monitors"
+NEEDED_KAFKA_TOPICS="ingest-attachments ingest-transactions ingest-events ingest-replay-recordings profiles ingest-occurrences ingest-metrics ingest-performance-metrics ingest-monitors ingest-feedback-events"
 for topic in $NEEDED_KAFKA_TOPICS; do
   if ! echo "$EXISTING_KAFKA_TOPICS" | grep -qE "(^| )$topic( |$)"; then
     $dc exec kafka kafka-topics --create --topic $topic --bootstrap-server kafka:9092


### PR DESCRIPTION
I recently migrated feedback off the ingest-events pipeline in all prod regions: see https://github.com/getsentry/sentry/issues/66100.

This isn't a pressing change for self-hosted, but without it, we can't clean up [this option](https://github.com/getsentry/sentry/blob/5a4e113c83b0a4581a7bb0fde67115de8e2f07df/src/sentry/options/defaults.py#L480) which we use like a FF [in relay](https://github.com/getsentry/relay/pull/3344).

Needed for https://github.com/getsentry/relay/pull/3604