### PR TITLE
Typo in config.example.yml

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -117,7 +117,7 @@ transaction-events.force-disable-internal-project: true
 # slack.client-id: <'client id'>
 # slack.client-secret: <client secret>
 # slack.signing-secret: <signing secret>
-## If legacy-app is True use verfication-token instead of signing-secret
+## If legacy-app is True use verification-token instead of signing-secret
 # slack.verification-token: <verification token>
 
 


### PR DESCRIPTION
typo


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
