### PR TITLE
Fix install: use dynamic docker root dir instead of hardcoded one

### DIFF
--- a/install/update-docker-volume-permissions.sh
+++ b/install/update-docker-volume-permissions.sh
@@ -3,9 +3,10 @@ echo "${_group}Ensuring Kafka and Zookeeper volumes have correct permissions ...
 # Only supporting platforms on linux x86 platforms and not apple silicon. I'm assuming that folks using apple silicon are doing it for dev purposes and it's difficult
 # to change permissions of docker volumes since it is run in a VM.
 if [[ "$DOCKER_PLATFORM" = "linux/amd64" && -n "$(docker volume ls -q -f name=sentry-zookeeper)" && -n "$(docker volume ls -q -f name=sentry-kafka)" ]]; then
-  zookeeper_data_dir="/var/lib/docker/volumes/sentry-zookeeper/_data"
-  kafka_data_dir="/var/lib/docker/volumes/sentry-kafka/_data"
-  zookeeper_log_data_dir="/var/lib/docker/volumes/${COMPOSE_PROJECT_NAME}_sentry-zookeeper-log/_data"
+  docker_root_dir=$(docker info --format '{{.DockerRootDir}}')
+  zookeeper_data_dir="${docker_root_dir}/volumes/sentry-zookeeper/_data"
+  kafka_data_dir="${docker_root_dir}/volumes/sentry-kafka/_data"
+  zookeeper_log_data_dir="${docker_root_dir}/volumes/${COMPOSE_PROJECT_NAME}_sentry-zookeeper-log/_data"
   chmod -R a+w $zookeeper_data_dir $kafka_data_dir $zookeeper_log_data_dir && returncode=$? || returncode=$?
   if [[ $returncode == "1" ]]; then
     echo "WARNING: Error when setting appropriate permissions for zookeeper, kafka, and zookeeper log docker volumes. This may corrupt your self-hosted install. See https://github.com/confluentinc/kafka-images/issues/127 for context on why this was added."


### PR DESCRIPTION


<!-- Describe your PR here. -->
Avoid using a hardcoded path to docker root dir. Instead, fetch the path dynamically and use it.

Use case: folks using a non standard docker root dir.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
