### PR TITLE
task: add check if install.sh was run with root privileges

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,19 @@ if [[ -n "$MSYSTEM" ]]; then
 fi
 
 # Check if script was executed with root/sudo
-if [ `id -u` -ne 0 ]
-  then echo Please run this script as root or using sudo!
-  exit
+if [ "$(id -u)" -ne 0 ]; then
+    if [ "$CI" != "true" ]; then
+        echo "You should be using sudo, are you sure you want to continue? [y/n]"
+        read -r answer
+        if [ "$answer" != "${answer#[Yy]}" ] ;then
+            echo "Continuing without sudo. This might cause issues later on."
+        else
+            echo "The script execution was stopped. Please run it again with sudo."
+            exit
+        fi
+    fi
 fi
+
 
 source install/_lib.sh
 

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,12 @@ if [[ -n "$MSYSTEM" ]]; then
   exit 1
 fi
 
+# Check if script was executed with root/sudo
+if [ `id -u` -ne 0 ]
+  then echo Please run this script as root or using sudo!
+  exit
+fi
+
 source install/_lib.sh
 
 # Pre-flight. No impact yet.

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ fi
 # Check if script was executed with root/sudo
 if [ "$(id -u)" -ne 0 ]; then
     if [ "$CI" != "true" ]; then
-        echo "You should be using sudo, are you sure you want to continue? [y/n]"
+        echo "It is recommended to run the script as the root user (by using sudo or as a direct root user) to avoid permission issues. Are you sure you want to continue? [y/n]"
         read -r answer
         if [ "$answer" != "${answer#[Yy]}" ] ;then
             echo "Continuing without sudo. This might cause issues later on."


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Story

Currently, it's possible to run the `install.sh` without root privileges.  
This could cause misunderstandings if errors are thrown while running the script without root.

I added a check, if the script was run with root privileges.



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

## Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
