### PR TITLE
Update minimum docker compose requirement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,9 +85,9 @@ jobs:
       fail-fast: false
       matrix:
         customizations: ["disabled", "enabled"]
-        compose_version: ["v2.0.1", "v2.26.0"]
+        compose_version: ["v2.19.0", "v2.26.0"]
         include:
-          - compose_version: "v2.0.1"
+          - compose_version: "v2.19.0"
             compose_path: "/usr/local/lib/docker/cli-plugins"
           - compose_version: "v2.26.0"
             compose_path: "/usr/local/lib/docker/cli-plugins"
@@ -136,7 +136,7 @@ jobs:
 
       - name: Integration Test
         run: |
-          if [ "${{ matrix.compose_version }}" = "v2.0.1" ]; then
+          if [ "${{ matrix.compose_version }}" = "v2.19.0" ]; then
             pytest --reruns 3 --cov --junitxml=junit.xml _integration-test/ --customizations=${{ matrix.customizations }}
           else
             pytest --cov --junitxml=junit.xml _integration-test/ --customizations=${{ matrix.customizations }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
 ## Requirements
 
 * Docker 19.03.6+
-* Compose 2.0.1+
+* Compose 2.19.0+
 * 4 CPU Cores
 * 16 GB RAM
 * 20 GB Free Disk Space

--- a/install/_min-requirements.sh
+++ b/install/_min-requirements.sh
@@ -1,6 +1,6 @@
 # Don't forget to update the README and othes docs when you change these!
 MIN_DOCKER_VERSION='19.03.6'
-MIN_COMPOSE_VERSION='2.0.1'
+MIN_COMPOSE_VERSION='2.19.0'
 MIN_RAM_HARD=3800 # MB
 MIN_RAM_SOFT=7800 # MB
 MIN_CPU_HARD=2


### PR DESCRIPTION
<!-- Describe your PR here. -->

Closes #3070

docker compose down <service> is now required in https://github.com/getsentry/self-hosted/blob/master/install/upgrade-clickhouse.sh#L27.
Here is the corresponding docker compose Changelog: https://docs.docker.com/compose/release-notes/#bug-fixes-and-enhancements-19

I was running the install script using docker compose v2.18.1, and the install failed with:

```
 Container sentry-self-hosted-clickhouse-1  Running
sentry-self-hosted-clickhouse-1   clickhouse-self-hosted-local   "/entrypoint.sh"    clickhouse          4 minutes ago       Up 31 seconds (healthy)   8123/tcp, 9000/tcp, 9009/tcp
unknown command "clickhouse" for "docker compose down"
Error in install/upgrade-clickhouse.sh:23.
'$dc down clickhouse' exited with status 1
-> ./install.sh:main:25
--> install/upgrade-clickhouse.sh:source:23

Looks like you've already sent this error to us, we're on it :)
```



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
