### PR TITLE
Different approach to editing permissions of docker volumes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Get latest self-hosted release version
         run: |
           LATEST_TAG=$(curl -s https://api.github.com/repos/getsentry/self-hosted/releases/latest | jq -r '.tag_name')
-          echo "LATEST_TAG=24.2.0" >> $GITHUB_ENV
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
 
       - name: Checkout latest release
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Get latest self-hosted release version
         run: |
           LATEST_TAG=$(curl -s https://api.github.com/repos/getsentry/self-hosted/releases/latest | jq -r '.tag_name')
-          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          echo "LATEST_TAG=24.2.0" >> $GITHUB_ENV
 
       - name: Checkout latest release
         uses: actions/checkout@v4
@@ -73,9 +73,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install current ref
-        run: |
-          # Hacky way to get around permissioning issues in update-docker-volume-permissions.sh script
-          sudo -E ./install.sh
+        run: ./install.sh
 
   integration-test:
     if: github.repository_owner == 'getsentry'

--- a/install/update-docker-volume-permissions.sh
+++ b/install/update-docker-volume-permissions.sh
@@ -3,7 +3,7 @@ echo "${_group}Ensuring Kafka and Zookeeper volumes have correct permissions ...
 # Only supporting platforms on linux x86 platforms and not apple silicon. I'm assuming that folks using apple silicon are doing it for dev purposes and it's difficult
 # to change permissions of docker volumes since it is run in a VM.
 if [[ "$DOCKER_PLATFORM" = "linux/amd64" && -n "$(docker volume ls -q -f name=sentry-zookeeper)" && -n "$(docker volume ls -q -f name=sentry-kafka)" ]]; then
-  docker run --rm -v sentry-zookeeper:/sentry-zookeeper-data -v sentry-kafka:/sentry-kafka-data -v sentry-zookeeper-log:/sentry-zookeeper-log-data busybox chmod -R a+w /sentry-zookeeper-data /sentry-kafka-data /sentry-zookeeper-log-data
+  docker run --rm -v "sentry-zookeeper:/sentry-zookeeper-data" -v "sentry-kafka:/sentry-kafka-data" -v "sentry-${COMPOSE_PROJECT_NAME}-zookeeper-log:/sentry-zookeeper-log-data" busybox chmod -R a+w /sentry-zookeeper-data /sentry-kafka-data /sentry-zookeeper-log-data
 fi
 
 echo "${_endgroup}"

--- a/install/update-docker-volume-permissions.sh
+++ b/install/update-docker-volume-permissions.sh
@@ -3,13 +3,7 @@ echo "${_group}Ensuring Kafka and Zookeeper volumes have correct permissions ...
 # Only supporting platforms on linux x86 platforms and not apple silicon. I'm assuming that folks using apple silicon are doing it for dev purposes and it's difficult
 # to change permissions of docker volumes since it is run in a VM.
 if [[ "$DOCKER_PLATFORM" = "linux/amd64" && -n "$(docker volume ls -q -f name=sentry-zookeeper)" && -n "$(docker volume ls -q -f name=sentry-kafka)" ]]; then
-  zookeeper_data_dir="/var/lib/docker/volumes/sentry-zookeeper/_data"
-  kafka_data_dir="/var/lib/docker/volumes/sentry-kafka/_data"
-  zookeeper_log_data_dir="/var/lib/docker/volumes/${COMPOSE_PROJECT_NAME}_sentry-zookeeper-log/_data"
-  chmod -R a+w $zookeeper_data_dir $kafka_data_dir $zookeeper_log_data_dir && returncode=$? || returncode=$?
-  if [[ $returncode == "1" ]]; then
-    echo "WARNING: Error when setting appropriate permissions for zookeeper, kafka, and zookeeper log docker volumes. This may corrupt your self-hosted install. See https://github.com/confluentinc/kafka-images/issues/127 for context on why this was added."
-  fi
+  docker run --rm -v sentry-zookeeper:/sentry-zookeeper-data -v sentry-kafka:/sentry-kafka-data -v sentry-zookeeper-log:/sentry-zookeeper-log-data busybox chmod -R a+w /sentry-zookeeper-data /sentry-kafka-data /sentry-zookeeper-log-data
 fi
 
 echo "${_endgroup}"

--- a/install/update-docker-volume-permissions.sh
+++ b/install/update-docker-volume-permissions.sh
@@ -3,7 +3,7 @@ echo "${_group}Ensuring Kafka and Zookeeper volumes have correct permissions ...
 # Only supporting platforms on linux x86 platforms and not apple silicon. I'm assuming that folks using apple silicon are doing it for dev purposes and it's difficult
 # to change permissions of docker volumes since it is run in a VM.
 if [[ "$DOCKER_PLATFORM" = "linux/amd64" && -n "$(docker volume ls -q -f name=sentry-zookeeper)" && -n "$(docker volume ls -q -f name=sentry-kafka)" ]]; then
-  docker run --rm -v "sentry-zookeeper:/sentry-zookeeper-data" -v "sentry-kafka:/sentry-kafka-data" -v "sentry-${COMPOSE_PROJECT_NAME}-zookeeper-log:/sentry-zookeeper-log-data" busybox chmod -R a+w /sentry-zookeeper-data /sentry-kafka-data /sentry-zookeeper-log-data
+  docker run --rm -v "sentry-zookeeper:/sentry-zookeeper-data" -v "sentry-kafka:/sentry-kafka-data" -v "${COMPOSE_PROJECT_NAME}_sentry-zookeeper-log:/sentry-zookeeper-log-data" busybox chmod -R a+w /sentry-zookeeper-data /sentry-kafka-data /sentry-zookeeper-log-data
 fi
 
 echo "${_endgroup}"

--- a/install/update-docker-volume-permissions.sh
+++ b/install/update-docker-volume-permissions.sh
@@ -2,7 +2,7 @@ echo "${_group}Ensuring Kafka and Zookeeper volumes have correct permissions ...
 
 # Only supporting platforms on linux x86 platforms and not apple silicon. I'm assuming that folks using apple silicon are doing it for dev purposes and it's difficult
 # to change permissions of docker volumes since it is run in a VM.
-if [[ "$DOCKER_PLATFORM" = "linux/amd64" && -n "$(docker volume ls -q -f name=sentry-zookeeper)" && -n "$(docker volume ls -q -f name=sentry-kafka)" ]]; then
+if [[ -n "$(docker volume ls -q -f name=sentry-zookeeper)" && -n "$(docker volume ls -q -f name=sentry-kafka)" ]]; then
   docker run --rm -v "sentry-zookeeper:/sentry-zookeeper-data" -v "sentry-kafka:/sentry-kafka-data" -v "${COMPOSE_PROJECT_NAME}_sentry-zookeeper-log:/sentry-zookeeper-log-data" busybox chmod -R a+w /sentry-zookeeper-data /sentry-kafka-data /sentry-zookeeper-log-data
 fi
 


### PR DESCRIPTION
Previously, we were using `sudo -E ./install.sh` to get around permissioning issues in CI when setting docker volume permissions. Using this approach, sudo is no longer needed in the install script to modify docker permissions if users do not have access to the docker volume directories