### PR TITLE
CI: Add upgrade test for last hard stop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,13 +44,22 @@ jobs:
     if: github.repository_owner == 'getsentry'
     runs-on: ubuntu-22.04
     name: "Sentry upgrade test"
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["latest", "hard-stop"]
     env:
       REPORT_SELF_HOSTED_ISSUES: 0
     steps:
-      - name: Get latest self-hosted release version
+      - name: Get self-hosted release version
         run: |
-          LATEST_TAG=$(curl -s https://api.github.com/repos/getsentry/self-hosted/releases/latest | jq -r '.tag_name')
-          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          if [ "${{ matrix.version }}" = "latest" ]; then
+            LATEST_TAG=$(curl -s https://api.github.com/repos/getsentry/self-hosted/releases/latest | jq -r '.tag_name')
+            echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          else
+            # Use latest hard stop version
+            echo "LATEST_TAG=23.6.2" >> $GITHUB_ENV
+          fi
 
       - name: Checkout latest release
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
             echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
           else
             # Use latest hard stop version
-            echo "LATEST_TAG=23.6.2" >> $GITHUB_ENV
+            echo "LATEST_TAG=24.1.0" >> $GITHUB_ENV
           fi
 
       - name: Checkout latest release

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
   postgres:
     <<: *restart_policy
     # Using the same postgres version as Sentry dev for consistency purposes
-    image: "postgres:14.11-alpine"
+    image: "postgres:14.11"
     healthcheck:
       <<: *healthcheck_defaults
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided

--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -17,8 +17,21 @@ if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
   # Wait for clickhouse
   wait_for_clickhouse
 
-  # In order to get to 23.8, we need to first upgrade go from 21.8 -> 22.8 -> 23.3 -> 23.8
+  # In order to get to 23.8, we need to first upgrade go from 20.3 -> 21.8 -> 22.8 -> 23.3 -> 23.8
   version=$($dc exec clickhouse clickhouse-client -q 'SELECT version()')
+  if [[ "$version" == "20.3.9.70" ]]; then
+    $dc down clickhouse
+    $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:21.8.13.1.altinitystable clickhouse
+    $dc up -d clickhouse
+    wait_for_clickhouse
+    version=$($dc exec clickhouse clickhouse-client -q 'SELECT version()')
+  elif [[ "$version" == "21.8.12.29.altinitydev.arm" ]]; then
+    $dc down clickhouse
+    $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:21.8.12.29.altinitydev.arm clickhouse
+    $dc up -d clickhouse
+    wait_for_clickhouse
+    version=$($dc exec clickhouse clickhouse-client -q 'SELECT version()')
+  fi
   if [[ "$version" == "21.8.13.1.altinitystable" || "$version" == "21.8.12.29.altinitydev.arm" ]]; then
     $dc down clickhouse
     $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:22.8.15.25.altinitystable clickhouse


### PR DESCRIPTION
This will help catch issues that happen during the upgrade from the latest hard stop to the most current Sentry