### PR TITLE
ref(spans): Add new feature flags needed

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -300,8 +300,6 @@ SENTRY_FEATURES.update(
             "organizations:insights-initial-modules",
             "organizations:mobile-ttid-ttfd-contribution",
             "organizations:performance-calculate-score-relay",
-            "organizations:performance-database-view",
-            "organizations:performance-screens-view",
             "organizations:spans-first-ui",
             "organizations:standalone-span-ingestion",
             "organizations:starfish-browser-resource-module-image-view",

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -296,6 +296,8 @@ SENTRY_FEATURES.update(
         + (
             "organizations:deprecate-fid-from-performance-score",
             "organizations:indexed-spans-extraction",
+            "organizations:insights-entry-points",
+            "organizations:insights-initial-modules",
             "organizations:mobile-ttid-ttfd-contribution",
             "organizations:performance-calculate-score-relay",
             "organizations:performance-database-view",

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -312,7 +312,6 @@ SENTRY_FEATURES.update(
             "organizations:starfish-browser-webvitals-use-backend-scores",
             "organizations:starfish-mobile-appstart",
             "projects:span-metrics-extraction",
-            "projects:span-metrics-extraction-addons",
         )  # starfish related flags
     }
 )

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -294,21 +294,23 @@ SENTRY_FEATURES.update(
             "projects:servicehooks",
         )
         + (
-            "projects:span-metrics-extraction",
+            "organizations:deprecate-fid-from-performance-score",
+            "organizations:indexed-spans-extraction",
+            "organizations:mobile-ttid-ttfd-contribution",
+            "organizations:performance-calculate-score-relay",
+            "organizations:performance-database-view",
+            "organizations:performance-screens-view",
+            "organizations:spans-first-ui",
+            "organizations:standalone-span-ingestion",
             "organizations:starfish-browser-resource-module-image-view",
             "organizations:starfish-browser-resource-module-ui",
             "organizations:starfish-browser-webvitals",
             "organizations:starfish-browser-webvitals-pageoverview-v2",
-            "organizations:starfish-browser-webvitals-use-backend-scores",
-            "organizations:performance-calculate-score-relay",
             "organizations:starfish-browser-webvitals-replace-fid-with-inp",
-            "organizations:deprecate-fid-from-performance-score",
-            "organizations:performance-database-view",
-            "organizations:performance-screens-view",
-            "organizations:mobile-ttid-ttfd-contribution",
+            "organizations:starfish-browser-webvitals-use-backend-scores",
             "organizations:starfish-mobile-appstart",
-            "organizations:standalone-span-ingestion",
-            "organizations:spans-first-ui",
+            "projects:span-metrics-extraction",
+            "projects:span-metrics-extraction-addons",
         )  # starfish related flags
     }
 )


### PR DESCRIPTION
We split the feature flags for span ingestion in 3 different buckets:
- indexed spans
- metrics extraction for some modules
- metrics extraction for add-on modules

This PR will make sure all 3 features are now enabled in self-hosted.