### PR TITLE
Bump Python SDK version used in tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-sentry-sdk>=1.39.2
+sentry-sdk>=2.4.0
 pytest>=8.0.0
 pytest-cov>=4.1.0
 pytest-rerunfailures>=11.0


### PR DESCRIPTION
`1.39.2` -> `2.4.0`

No code changes necessary, the API we're using in the integration tests has not changed in 2.x.