### PR TITLE
feat: add insights feature flags

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -310,6 +310,7 @@ SENTRY_FEATURES.update(
             "organizations:starfish-browser-webvitals-use-backend-scores",
             "organizations:starfish-mobile-appstart",
             "projects:span-metrics-extraction",
+            "projects:span-metrics-extraction-addons",
         )  # starfish related flags
     }
 )

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -298,6 +298,7 @@ SENTRY_FEATURES.update(
             "organizations:indexed-spans-extraction",
             "organizations:insights-entry-points",
             "organizations:insights-initial-modules",
+            "organizations:insights-addon-modules",
             "organizations:mobile-ttid-ttfd-contribution",
             "organizations:performance-calculate-score-relay",
             "organizations:standalone-span-ingestion",
@@ -309,9 +310,6 @@ SENTRY_FEATURES.update(
             "organizations:starfish-browser-webvitals-use-backend-scores",
             "organizations:starfish-mobile-appstart",
             "projects:span-metrics-extraction",
-            "organizations:insights-entry-points",
-            "organizations:insights-initial-modules",
-            "organizations:insights-addon-modules",
         )  # starfish related flags
     }
 )

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -300,7 +300,6 @@ SENTRY_FEATURES.update(
             "organizations:insights-initial-modules",
             "organizations:mobile-ttid-ttfd-contribution",
             "organizations:performance-calculate-score-relay",
-            "organizations:spans-first-ui",
             "organizations:standalone-span-ingestion",
             "organizations:starfish-browser-resource-module-image-view",
             "organizations:starfish-browser-resource-module-ui",
@@ -310,6 +309,9 @@ SENTRY_FEATURES.update(
             "organizations:starfish-browser-webvitals-use-backend-scores",
             "organizations:starfish-mobile-appstart",
             "projects:span-metrics-extraction",
+            "organizations:insights-entry-points",
+            "organizations:insights-initial-modules",
+            "organizations:insights-addon-modules",
         )  # starfish related flags
     }
 )


### PR DESCRIPTION
Closes #3145

After this is merged, we should create a new patch release 24.6.1 to handle that specific issue, since during the time of the self-hosted release, the Insights team ported a few changes from Performance -> Insights.

Also removes `spans-first-ui` per this PR https://github.com/getsentry/sentry/pull/72255

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
