### PR TITLE
Update sentry-admin.sh to select its own working directory

### DIFF
--- a/sentry-admin.sh
+++ b/sentry-admin.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set the script directory as working directory.
+cd $(dirname $0)
+
 # Detect docker and platform state.
 source install/dc-detect-version.sh
 source install/detect-platform.sh


### PR DESCRIPTION
`sentry-admin.sh` only works when called from the working directory and not using its absolute path.

This change makes it also callable using its absolute path.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
