### PR TITLE
Use CDN by default for JS SDK Loader

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -363,3 +363,9 @@ CSP_REPORT_ONLY = True
 # https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS
 
 # CSRF_TRUSTED_ORIGINS = ["https://example.com", "http://127.0.0.1:9000"]
+
+#################
+# JS SDK Loader #
+#################
+
+JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"


### PR DESCRIPTION
In the Sentry UI you can get a "Loader Script", however currently this services a JS files that results in a console warning that the loader "isn't working anymore". However this is not very apparent from the UI and still works great on SaaS. 

What the loader script currently serves (with some other boilerplate):

```js
console.warn("The Sentry loader you are trying to use isn't working anymore, check your configuration.");
```

This has been discussed at length in multiple places and venues (most recent: getsentry/sentry#22715). And the conclusion looks to be that it's very hard to enable for self-hosted. @aldy505 event created a super cool container to server the needed files: https://github.com/getsentry/sentry/issues/22715#issuecomment-2129862063.

However... I decided to go digging around the code and it looks like it isn't as hard 🙈

It just wants a URL where to load the CDN bundles from and Sentry already provides this just fine of course.

Long story short, I'd like to propose adding this as the default config so the loader script also works on self-hosted with the Sentry CDN as backing for where to load the actual JS files from. Since it's currently just "broken" when installing self-hosted this seems like a nice improvement.

It would be better if the JS files are also self-hosteable, but I think having this as a default is better than the current broken default and easy to disable by just commenting this out. We can also leave this commented out by default of course but when you don't mind the JS files coming from the Sentry CDN this "fixes" the loader script 😄 