### PR TITLE
Fix: errors only config flag

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -365,4 +365,4 @@ CSP_REPORT_ONLY = True
 # CSRF_TRUSTED_ORIGINS = ["https://example.com", "http://127.0.0.1:9000"]
 
 # If you would like to use self-hosted Sentry with only errors enabled, please set this
-SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") == "feature-complete"
+SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") != "feature-complete"


### PR DESCRIPTION
This was a bug, I had `SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") != "feature-complete"` locally in my sentry.conf.py when testing

relevant issue: https://github.com/getsentry/self-hosted/issues/2533