### PR TITLE
feat: enable traces

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -301,6 +301,7 @@ SENTRY_FEATURES.update(
             "organizations:insights-addon-modules",
             "organizations:mobile-ttid-ttfd-contribution",
             "organizations:performance-calculate-score-relay",
+            "organizations:performance-trace-explorer",
             "organizations:standalone-span-ingestion",
             "organizations:starfish-browser-resource-module-image-view",
             "organizations:starfish-browser-resource-module-ui",


### PR DESCRIPTION
**NOTE: I don't know if the feature flag will be removed in the future. But considering we have `errors-only` version of Sentry, I don't think this will be removed, at least for the near future. So I'm adding this here.**

Some people are already asking about it.

On Github: https://github.com/getsentry/self-hosted/issues/3214
On Discord: https://discord.com/channels/621778831602221064/796028405833007104/1260595924774813757, https://discord.com/channels/621778831602221064/796028405833007104/1266233909197410335

This is the "Traces" page:

![image](https://github.com/user-attachments/assets/3a180195-3141-499d-ab08-c379a011b9cb)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
