### PR TITLE
remove python-dev

### DIFF
--- a/sentry/enhance-image.example.sh
+++ b/sentry/enhance-image.example.sh
@@ -3,5 +3,5 @@
 # Enhance the base $SENTRY_IMAGE with additional dependencies, plugins - see https://github.com/getsentry/self-hosted#enhance-sentry-image
 # For example:
 # apt-get update
-# apt-get install -y gcc libsasl2-dev python-dev libldap2-dev libssl-dev
+# apt-get install -y gcc libsasl2-dev libldap2-dev libssl-dev
 # pip install python-ldap


### PR DESCRIPTION
this package does not exist on modern debians, the headers are already available in the docker image anyway

resolves #3226




<!-- Describe your PR here. -->