### PR TITLE
Revert "ref(feedback): cleanup topic rollout option"

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -325,6 +325,10 @@ SENTRY_FEATURES.update(
     }
 )
 
+# Temporary flag to mark User Feedback to be produced to the dedicated feedback topic by relay.
+# This will be removed at a later time after it's considered stable and fully rolled out.
+SENTRY_OPTIONS["feedback.ingest-topic.rollout-rate"] = 1.0
+
 #######################
 # MaxMind Integration #
 #######################


### PR DESCRIPTION
Reverts getsentry/self-hosted#3256

Reverting to wait for the relay deploy (happening tomorrow). Plan to reopen in a few days, to account for potential reverts