### PR TITLE
Update check-minimum-requirements.sh

### DIFF
--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -4,8 +4,11 @@ source install/_min-requirements.sh
 
 # Check the version of $1 is greater than or equal to $2 using sort. Note: versions must be stripped of "v"
 function vergte() {
-  printf "%s\n%s" $1 $2 | sort --version-sort --check=quiet --reverse
-  echo $?
+  if [[ "$(printf "%s\n%s" "$1" "$2" | sort --version-sort | head -n 1)" == "$2" ]]; then
+    return 0  # $1 is greater than or equal to $2
+  else
+    return 1  # $1 is less than $2
+  fi
 }
 
 DOCKER_VERSION=$(docker version --format '{{.Server.Version}}' || echo '')


### PR DESCRIPTION
fix wrong version comparison in minimum requirements check




This humble edit, tries to fix wrong version comparison in `check-minimum-requirements.sh` file.



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
