### PR TITLE
ref: allow hosted js sdk bundles

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,5 @@ HEALTHCHECK_RETRIES=10
 # Caution: Raising max connections of postgres increases CPU and RAM usage
 # see https://github.com/getsentry/self-hosted/pull/2740 for more information
 POSTGRES_MAX_CONNECTIONS=100
+# Set SETUP_JS_SDK_ASSETS to 1 to enable the setup of JS SDK assets
+# SETUP_JS_SDK_ASSETS=1

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -2,6 +2,7 @@
 
 source _unit-test/_test_setup.sh
 source install/dc-detect-version.sh
+$dcb --force-rm web
 
 export SETUP_JS_SDK_ASSETS=1
 export SETUP_JS_SDK_KEEP_OLD_ASSETS=1

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -11,7 +11,7 @@ sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-s
 sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx tree /var/www/js-sdk | tail -n 1)
 
 # `sdk_files` should contains 2 lines, `7.*` and `8.*`
-test "2" == "$(echo "$sdk_files" | grep '[0-9]+$' | wc -l )"
+test "2" == "$(echo "$sdk_files" | grep '[0-9]+$' | wc -l)"
 
 # `sdk_tree` should outputs "3 directories, 10 files"
 test "3 directories, 10 files" == "$(echo "$sdk_tree")"

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -12,10 +12,10 @@ sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www" ngi
 sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www" nginx tree /var/www/js-sdk/ | tail -n 1)
 
 # `sdk_files` should contains 2 lines, `7.*` and `8.*`
-total_directories=$(echo "$sdk_files" | grep '{7,8}\.[0-9]+$' | wc -l)
-echo "$sdk_files $total_directories"
-test "2" == "$total_directories"
-echo "Pass"
+# total_directories=$(echo "$sdk_files" | grep '{7,8}\.[0-9]+$' | wc -l)
+# echo "$sdk_files $total_directories"
+# test "2" == "$total_directories"
+# echo "Pass"
 
 # `sdk_tree` should outputs "3 directories, 10 files"
 echo "$sdk_tree"

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -14,8 +14,10 @@ sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sd
 
 # `sdk_files` should contains 2 lines, `7.*` and `8.*`
 test "2" == "$(echo "$sdk_files" | grep '[0-9]+$' | wc -l)"
+echo "Pass"
 
 # `sdk_tree` should outputs "3 directories, 10 files"
 test "3 directories, 10 files" == "$(echo "$sdk_tree")"
+echo "Pass"
 
 report_success

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -12,14 +12,15 @@ sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www" ngi
 sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www" nginx tree /var/www/js-sdk/ | tail -n 1)
 
 # `sdk_files` should contains 2 lines, `7.*` and `8.*`
-# total_directories=$(echo "$sdk_files" | grep '{7,8}\.[0-9]+$' | wc -l)
-# echo "$sdk_files $total_directories"
-# test "2" == "$total_directories"
-# echo "Pass"
+echo $sdk_files
+total_directories=$(echo "$sdk_files" | grep -c '[78]\.[0-9]*\.[0-9]*$')
+echo $total_directories
+test "2" == "$total_directories"
+echo "Pass"
 
 # `sdk_tree` should outputs "3 directories, 10 files"
 echo "$sdk_tree"
-test "3 directories, 10 files" == "$(echo "$sdk_tree")"
+test "2 directories, 10 files" == "$(echo "$sdk_tree")"
 echo "Pass"
 
 report_success

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -18,7 +18,7 @@ echo $total_directories
 test "2" == "$total_directories"
 echo "Pass"
 
-# `sdk_tree` should outputs "3 directories, 10 files"
+# `sdk_tree` should outputs "2 directories, 10 files"
 echo "$sdk_tree"
 test "2 directories, 10 files" == "$(echo "$sdk_tree")"
 echo "Pass"

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -9,14 +9,16 @@ export SETUP_JS_SDK_KEEP_OLD_ASSETS=1
 
 source install/setup-js-sdk-assets.sh
 
-sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx ls \-lah /var/www/js-sdk)
+sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx ls -lah /var/www/js-sdk)
 sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx tree /var/www/js-sdk | tail -n 1)
 
 # `sdk_files` should contains 2 lines, `7.*` and `8.*`
+echo "$sdk_files"
 test "2" == "$(echo "$sdk_files" | grep '[0-9]+$' | wc -l)"
 echo "Pass"
 
 # `sdk_tree` should outputs "3 directories, 10 files"
+echo "$sdk_tree"
 test "3 directories, 10 files" == "$(echo "$sdk_tree")"
 echo "Pass"
 

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -9,8 +9,8 @@ export SETUP_JS_SDK_KEEP_OLD_ASSETS=1
 
 source install/setup-js-sdk-assets.sh
 
-sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx ls -lah /var/www/js-sdk)
-sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx tree /var/www/js-sdk | tail -n 1)
+sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www" nginx ls -lah /var/www/js-sdk/)
+sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www" nginx tree /var/www/js-sdk/ | tail -n 1)
 
 # `sdk_files` should contains 2 lines, `7.*` and `8.*`
 echo "$sdk_files"

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -5,7 +5,6 @@ source install/dc-detect-version.sh
 $dcb --force-rm web
 
 export SETUP_JS_SDK_ASSETS=1
-export SETUP_JS_SDK_KEEP_OLD_ASSETS=1
 
 source install/setup-js-sdk-assets.sh
 
@@ -13,8 +12,9 @@ sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www" ngi
 sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www" nginx tree /var/www/js-sdk/ | tail -n 1)
 
 # `sdk_files` should contains 2 lines, `7.*` and `8.*`
-echo "$sdk_files"
-test "2" == "$(echo "$sdk_files" | grep '[0-9]+$' | wc -l)"
+total_directories=$(echo "$sdk_files" | grep '{7,8}\.[0-9]+$' | wc -l)
+echo "$sdk_files $total_directories"
+test "2" == "$total_directories"
 echo "Pass"
 
 # `sdk_tree` should outputs "3 directories, 10 files"

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 source _unit-test/_test_setup.sh
+source install/dc-detect-version.sh
 
 export SETUP_JS_SDK_ASSETS=1
 export SETUP_JS_SDK_KEEP_OLD_ASSETS=1

--- a/_unit-test/js-sdk-assets-test.sh
+++ b/_unit-test/js-sdk-assets-test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+source _unit-test/_test_setup.sh
+
+export SETUP_JS_SDK_ASSETS=1
+export SETUP_JS_SDK_KEEP_OLD_ASSETS=1
+
+source install/setup-js-sdk-assets.sh
+
+sdk_files=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx ls \-lah /var/www/js-sdk)
+sdk_tree=$(docker compose run --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx tree /var/www/js-sdk | tail -n 1)
+
+# `sdk_files` should contains 2 lines, `7.*` and `8.*`
+test "2" == "$(echo "$sdk_files" | grep '[0-9]+$' | wc -l )"
+
+# `sdk_tree` should outputs "3 directories, 10 files"
+test "3 directories, 10 files" == "$(echo "$sdk_tree")"
+
+report_success

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -460,6 +460,7 @@ services:
         source: ./nginx
         target: /etc/nginx
       - sentry-nginx-cache:/var/cache/nginx
+      - sentry-nginx-www:/var/www
     depends_on:
       - web
       - relay
@@ -528,6 +529,11 @@ volumes:
   sentry-clickhouse:
     external: true
   sentry-symbolicator:
+    external: true
+  # This volume stores JS SDK assets, this is created as an external volume
+  # to minimize hiccups created by the nginx container and its' dependencies.
+  # The data inside this volume should be cleaned periodically on upgrades.
+  sentry-nginx-www:
     external: true
   # This volume stores profiles and should be persisted.
   # Not being external will still persist data across restarts.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -534,7 +534,6 @@ volumes:
   # to minimize hiccups created by the nginx container and its' dependencies.
   # The data inside this volume should be cleaned periodically on upgrades.
   sentry-nginx-www:
-    external: true
   # This volume stores profiles and should be persisted.
   # Not being external will still persist data across restarts.
   # It won't persist if someone does a docker compose down -v.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -530,9 +530,8 @@ volumes:
     external: true
   sentry-symbolicator:
     external: true
-  # This volume stores JS SDK assets, this is created as an external volume
-  # to minimize hiccups created by the nginx container and its' dependencies.
-  # The data inside this volume should be cleaned periodically on upgrades.
+  # This volume stores JS SDK assets and the data inside this volume should
+  # be cleaned periodically on upgrades.
   sentry-nginx-www:
   # This volume stores profiles and should be persisted.
   # Not being external will still persist data across restarts.

--- a/install.sh
+++ b/install.sh
@@ -36,4 +36,5 @@ source install/bootstrap-snuba.sh
 source install/upgrade-postgres.sh
 source install/set-up-and-migrate-database.sh
 source install/geoip.sh
+source install/setup-js-sdk-assets.sh
 source install/wrap-up.sh

--- a/install/create-docker-volumes.sh
+++ b/install/create-docker-volumes.sh
@@ -6,6 +6,5 @@ echo "Created $(docker volume create --name=sentry-kafka)."
 echo "Created $(docker volume create --name=sentry-postgres)."
 echo "Created $(docker volume create --name=sentry-redis)."
 echo "Created $(docker volume create --name=sentry-symbolicator)."
-echo "Created $(docker volume create --name=sentry-nginx-www)."
 
 echo "${_endgroup}"

--- a/install/create-docker-volumes.sh
+++ b/install/create-docker-volumes.sh
@@ -6,5 +6,6 @@ echo "Created $(docker volume create --name=sentry-kafka)."
 echo "Created $(docker volume create --name=sentry-postgres)."
 echo "Created $(docker volume create --name=sentry-redis)."
 echo "Created $(docker volume create --name=sentry-symbolicator)."
+echo "Created $(docker volume create --name=sentry-nginx-www)."
 
 echo "${_endgroup}"

--- a/install/setup-js-sdk-assets.sh
+++ b/install/setup-js-sdk-assets.sh
@@ -1,4 +1,5 @@
-# This will only run if the SETUP_JS_SDK_ASSETS environment variable is set to 1
+# This will only run if the SETUP_JS_SDK_ASSETS environment variable is set to 1.
+# Think of this as some kind of a feature flag.
 if [[ "${SETUP_JS_SDK_ASSETS:-}" == "1" ]]; then
   echo "${_group}Setting up JS SDK assets"
 

--- a/install/setup-js-sdk-assets.sh
+++ b/install/setup-js-sdk-assets.sh
@@ -8,20 +8,20 @@ if [[ "${SETUP_JS_SDK_ASSETS:-}" == "1" ]]; then
   # `SETUP_JS_SDK_KEEP_OLD_ASSETS` to any value.
   if [[ -z "${SETUP_JS_SDK_KEEP_OLD_ASSETS:-}" ]]; then
     echo "Cleaning up old JS SDK assets..."
-    docker run --rm -v "sentry-nginx-www:/js-sdk" busybox rm -rf /js-sdk/*
+    $dcr --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx rm -rf /var/www/js-sdk/*
   fi
 
   $dbuild -t sentry-self-hosted-jq-local --platform="$DOCKER_PLATFORM" jq
 
   jq="docker run --rm -i sentry-self-hosted-jq-local"
 
-  latest_js_v7=$($dc exec web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("7.")))) | .[0]')
-  latest_js_v8=$($dc exec web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("8.")))) | .[0]')
+  latest_js_v7=$($dcr --no-deps -T web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("7.")))) | .[0]')
+  latest_js_v8=$($dcr --no-deps -T web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("8.")))) | .[0]')
 
   # Download those two using wget
   for version in "${latest_js_v7}" "${latest_js_v8}"; do
     for variant in "tracing" "tracing.replay" "replay" "tracing.replay.feedback" "feedback"; do
-      docker run --rm -v "sentry-nginx-www:/js-sdk" busybox wget -q -O /js-sdk/${version}/bundle.${variant}.min.js "https://browser.sentry-cdn.com/${version}/bundle.${variant}.min.js"
+      $dcr --no-deps --rm -v "sentry-nginx-www:/js-sdk" nginx wget -q -O /var/www/js-sdk/${version}/bundle.${variant}.min.js "https://browser.sentry-cdn.com/${version}/bundle.${variant}.min.js"
     done
   done
 

--- a/install/setup-js-sdk-assets.sh
+++ b/install/setup-js-sdk-assets.sh
@@ -8,7 +8,7 @@ if [[ "${SETUP_JS_SDK_ASSETS:-}" == "1" ]]; then
   # `SETUP_JS_SDK_KEEP_OLD_ASSETS` to any value.
   if [[ -z "${SETUP_JS_SDK_KEEP_OLD_ASSETS:-}" ]]; then
     echo "Cleaning up old JS SDK assets..."
-    $dcr --no-deps --rm -v "sentry-nginx-www:/var/www/js-sdk" nginx rm -rf /var/www/js-sdk/*
+    $dcr --no-deps --rm -v "sentry-nginx-www:/var/www" nginx rm -rf /var/www/js-sdk/*
   fi
 
   $dbuild -t sentry-self-hosted-jq-local --platform="$DOCKER_PLATFORM" jq
@@ -27,9 +27,9 @@ if [[ "${SETUP_JS_SDK_ASSETS:-}" == "1" ]]; then
 
   # Download those two using wget
   for version in "${latest_js_v7}" "${latest_js_v8}"; do
-    $dcr --no-deps --rm -v "sentry-nginx-www:/js-sdk" nginx mkdir -p /var/www/js-sdk/${version}
+    $dcr --no-deps --rm -v "sentry-nginx-www:/var/www" nginx mkdir -p /var/www/js-sdk/${version}
     for variant in "tracing" "tracing.replay" "replay" "tracing.replay.feedback" "feedback"; do
-      $dcr --no-deps --rm -v "sentry-nginx-www:/js-sdk" nginx wget -q -O /var/www/js-sdk/${version}/bundle.${variant}.min.js "https://browser.sentry-cdn.com/${version}/bundle.${variant}.min.js"
+      $dcr --no-deps --rm -v "sentry-nginx-www:/var/www" nginx wget -q -O /var/www/js-sdk/${version}/bundle.${variant}.min.js "https://browser.sentry-cdn.com/${version}/bundle.${variant}.min.js"
     done
   done
 

--- a/install/setup-js-sdk-assets.sh
+++ b/install/setup-js-sdk-assets.sh
@@ -1,12 +1,12 @@
 # This will only run if the SETUP_JS_SDK_ASSETS environment variable is set to 1
-if [[ "$SETUP_JS_SDK_ASSETS" == "1" ]]; then
+if [[ "${SETUP_JS_SDK_ASSETS:-}" == "1" ]]; then
   echo "${_group}Setting up JS SDK assets"
 
   # If the `sentry-nginx-www` volume exists, we need to prune the contents.
   # We don't want to fill the volume with old JS SDK assets.
   # If people want to keep the old assets, they can set the environment variable
   # `SETUP_JS_SDK_KEEP_OLD_ASSETS` to any value.
-  if [[ -z "$SETUP_JS_SDK_KEEP_OLD_ASSETS" ]]; then
+  if [[ -z "${SETUP_JS_SDK_KEEP_OLD_ASSETS:-}" ]]; then
     echo "Cleaning up old JS SDK assets..."
     docker run --rm -v "sentry-nginx-www:/js-sdk" busybox rm -rf /js-sdk/*
   fi

--- a/install/setup-js-sdk-assets.sh
+++ b/install/setup-js-sdk-assets.sh
@@ -15,11 +15,12 @@ if [[ "${SETUP_JS_SDK_ASSETS:-}" == "1" ]]; then
 
   jq="docker run --rm -i sentry-self-hosted-jq-local"
 
-  latest_js_v7=$($dcr --no-deps -T web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("7.")))) | .[0]')
-  latest_js_v8=$($dcr --no-deps -T web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("8.")))) | .[0]')
+  latest_js_v7=$($dcr --no-deps --rm -T web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("7.")))) | .[0]')
+  latest_js_v8=$($dcr --no-deps --rm -T web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("8.")))) | .[0]')
 
   # Download those two using wget
   for version in "${latest_js_v7}" "${latest_js_v8}"; do
+    $dcr --no-deps --rm -v "sentry-nginx-www:/js-sdk" nginx mkdir -p /var/www/js-sdk/${version}
     for variant in "tracing" "tracing.replay" "replay" "tracing.replay.feedback" "feedback"; do
       $dcr --no-deps --rm -v "sentry-nginx-www:/js-sdk" nginx wget -q -O /var/www/js-sdk/${version}/bundle.${variant}.min.js "https://browser.sentry-cdn.com/${version}/bundle.${variant}.min.js"
     done

--- a/install/setup-js-sdk-assets.sh
+++ b/install/setup-js-sdk-assets.sh
@@ -23,6 +23,8 @@ if [[ "${SETUP_JS_SDK_ASSETS:-}" == "1" ]]; then
   latest_js_v7=$(echo "$loader_registry" | $jq -r '.versions | reverse | map(select(.|any(.; startswith("7.")))) | .[0]')
   latest_js_v8=$(echo "$loader_registry" | $jq -r '.versions | reverse | map(select(.|any(.; startswith("8.")))) | .[0]')
 
+  echo "Found JS SDKs v${latest_js_v7} and v${latest_js_v8}, downloading from upstream.."
+
   # Download those two using wget
   for version in "${latest_js_v7}" "${latest_js_v8}"; do
     $dcr --no-deps --rm -v "sentry-nginx-www:/js-sdk" nginx mkdir -p /var/www/js-sdk/${version}

--- a/install/setup-js-sdk-assets.sh
+++ b/install/setup-js-sdk-assets.sh
@@ -1,0 +1,29 @@
+# This will only run if the SETUP_JS_SDK_ASSETS environment variable is set to 1
+if [[ "$SETUP_JS_SDK_ASSETS" == "1" ]]; then
+  echo "${_group}Setting up JS SDK assets"
+
+  # If the `sentry-nginx-www` volume exists, we need to prune the contents.
+  # We don't want to fill the volume with old JS SDK assets.
+  # If people want to keep the old assets, they can set the environment variable
+  # `SETUP_JS_SDK_KEEP_OLD_ASSETS` to any value.
+  if [[ -z "$SETUP_JS_SDK_KEEP_OLD_ASSETS" ]]; then
+    echo "Cleaning up old JS SDK assets..."
+    docker run --rm -v "sentry-nginx-www:/js-sdk" busybox rm -rf /js-sdk/*
+  fi
+
+  $dbuild -t sentry-self-hosted-jq-local --platform="$DOCKER_PLATFORM" jq
+
+  jq="docker run --rm -i sentry-self-hosted-jq-local"
+
+  latest_js_v7=$($dc exec web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("7.")))) | .[0]')
+  latest_js_v8=$($dc exec web cat /usr/src/sentry/src/sentry/loader/_registry.json | $jq -r '.versions | reverse | map(select(.|any(.; startswith("8.")))) | .[0]')
+
+  # Download those two using wget
+  for version in "${latest_js_v7}" "${latest_js_v8}"; do
+    for variant in "tracing" "tracing.replay" "replay" "tracing.replay.feedback" "feedback"; do
+      docker run --rm -v "sentry-nginx-www:/js-sdk" busybox wget -q -O /js-sdk/${version}/bundle.${variant}.min.js "https://browser.sentry-cdn.com/${version}/bundle.${variant}.min.js"
+    done
+  done
+
+  echo "${_endgroup}"
+fi

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -91,7 +91,7 @@ http {
 		location ^~ /js-sdk/ {
 			autoindex on;
 			root  /var/www/js-sdk;
-		} 
+		}
 		location / {
 			proxy_pass http://sentry;
 		}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -88,6 +88,10 @@ http {
 		location ^~ /api/0/relays/ {
 			proxy_pass http://relay;
 		}
+		location ^~ /js-sdk/ {
+			autoindex on;
+			root  /var/www/js-sdk;
+		} 
 		location / {
 			proxy_pass http://sentry;
 		}

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -378,6 +378,12 @@ CSP_REPORT_ONLY = True
 # JS SDK Loader #
 #################
 
+# Configure Sentry JS SDK bundle URL template for Loader Scripts.
+# Learn more about the Loader Scripts: https://docs.sentry.io/platforms/javascript/install/loader/
+
+# If you wish to host your own JS SDK bundles, set `SETUP_JS_SDK_ASSETS` environment variable to `1`
+# on your `.env` or `.env.custom` file. Then, replace `browser.sentry-cdn.com` with your own public URL.
+# For example: `https://sentry.example.com/bundles/sentry-bundle.min.js`
 JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
 
 

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -382,8 +382,13 @@ CSP_REPORT_ONLY = True
 # Learn more about the Loader Scripts: https://docs.sentry.io/platforms/javascript/install/loader/
 
 # If you wish to host your own JS SDK bundles, set `SETUP_JS_SDK_ASSETS` environment variable to `1`
-# on your `.env` or `.env.custom` file. Then, replace `browser.sentry-cdn.com` with your own public URL.
-# For example: `https://sentry.example.com/bundles/sentry-bundle.min.js`
+# on your `.env` or `.env.custom` file. Then, replace the value below with your own public URL.
+# For example: "https://sentry.example.com/js-sdk/%s/bundle%s.min.js"
+#
+# By default, the previous JS SDK assets version will be pruned during upgrades, if you wish
+# to keep the old assets, set `SETUP_JS_SDK_KEEP_OLD_ASSETS` environment variable to any value on
+# your `.env` or `.env.custom` file. The files should only be a few KBs, and this might be useful
+# if you're using it directly like a CDN instead of using the loader script.
 JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
 
 


### PR DESCRIPTION
Since this is hanging on my branch, I guess I'll make it out here. A part of making the JS SDK loader script available on the self-hosted sentry. Refer to https://github.com/getsentry/sentry/issues/22715.

Since not everyone is happy on hosting the JS SDK themself, therefore I made it into a feature flag. Set `SETUP_JS_SDK_ASSETS=1` on the `.env` file to enable the script. Also set `SETUP_JS_SDK_KEEP_OLD_ASSETS=1` to never delete (or basically cleanup) previous JS SDK version.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
