### PR TITLE
docs: explicitly specify `mail.use-{tls,ssl}` is mutually exclusive

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -12,13 +12,14 @@ mail.host: 'smtp'
 # mail.port: 25
 # mail.username: ''
 # mail.password: ''
+# NOTE: `mail.use-tls` and `mail.use-ssl` are mutually exclusive and should not
+#        appear at the same time. Only uncomment one of them.
 # mail.use-tls: false
 # mail.use-ssl: false
 
 # NOTE: The following 2 configs (mail.from and mail.list-namespace) are set
 #       through SENTRY_MAIL_HOST in sentry.conf.py so remove those first if
 #       you want your values in this file to be effective!
-
 
 # The email address to send on behalf of
 # mail.from: 'root@localhost' or ...


### PR DESCRIPTION
I don't remember if it's on Discord or on Github issues, but someone had a problem setting this up and although it's Django's behavior, not everyone code in Django.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
