### PR TITLE
chore: replace old URLs of the repo with the new docs

### DIFF
--- a/sentry/Dockerfile
+++ b/sentry/Dockerfile
@@ -8,6 +8,6 @@ RUN if [ -s /usr/src/sentry/enhance-image.sh ]; then \
 fi
 
 RUN if [ -s /usr/src/sentry/requirements.txt ]; then \
-    echo "sentry/requirements.txt is deprecated, use sentry/enhance-image.sh - see https://github.com/getsentry/self-hosted#enhance-sentry-image"; \
+    echo "sentry/requirements.txt is deprecated, use sentry/enhance-image.sh - see https://develop.sentry.dev/self-hosted/#enhance-sentry-image"; \
     pip install -r /usr/src/sentry/requirements.txt; \
 fi

--- a/sentry/enhance-image.example.sh
+++ b/sentry/enhance-image.example.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Enhance the base $SENTRY_IMAGE with additional dependencies, plugins - see https://github.com/getsentry/self-hosted#enhance-sentry-image
+# Enhance the base $SENTRY_IMAGE with additional dependencies, plugins - see https://develop.sentry.dev/self-hosted/#enhance-sentry-image
 # For example:
 # apt-get update
 # apt-get install -y gcc libsasl2-dev libldap2-dev libssl-dev

--- a/sentry/entrypoint.sh
+++ b/sentry/entrypoint.sh
@@ -6,7 +6,7 @@ if [ "$(ls -A /usr/local/share/ca-certificates/)" ]; then
 fi
 
 if [ -e /etc/sentry/requirements.txt ]; then
-  echo "sentry/requirements.txt is deprecated, use sentry/enhance-image.sh - see https://github.com/getsentry/self-hosted#enhance-sentry-image"
+  echo "sentry/requirements.txt is deprecated, use sentry/enhance-image.sh - see https://develop.sentry.dev/self-hosted/#enhance-sentry-image"
 fi
 
 source /docker-entrypoint.sh

--- a/sentry/requirements.example.txt
+++ b/sentry/requirements.example.txt
@@ -1,1 +1,1 @@
-# sentry/requirements.txt is deprecated, use sentry/enhance-image.sh - see https://github.com/getsentry/self-hosted#enhance-sentry-image
+# sentry/requirements.txt is deprecated, use sentry/enhance-image.sh - see https://develop.sentry.dev/self-hosted/#enhance-sentry-image


### PR DESCRIPTION
<!-- Describe your PR here. -->

I updated the old links to the repository documentation that were changed in PR #3307  (Issue #1996 )

I set the link to the Sentry domain as I saw in other parts of the application. If necessary, I can change them to the links from the MK file in the repository.

https://github.com/getsentry/sentry-docs/blob/master/develop-docs/self-hosted/index.mdx#enhance-sentry-image

Thank you.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
