### PR TITLE
releng: link to Sentry release in release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -20,6 +20,7 @@ body:
           - [ ] Check to make sure the new release branch in self-hosted includes the appropriate CalVer images.
           - [ ] Accept (publish) the release.
           - [ ] Edit [release notes](https://github.com/getsentry/self-hosted/releases).
+            - [ ] Add a link to the corresponding [Sentry release](https://github.com/getsentry/sentry/releases).
         - [ ] Follow up.
           - [ ] [Create the next release issue](https://github.com/getsentry/self-hosted/issues/new?assignees=&labels=&projects=&template=release.yml) and link it from this one.
             - _replace with link_


### PR DESCRIPTION
When crafting the release notes for the self-hosted project, adding a link to the Sentry project release would be beneficial for users only receiving notifications the self-hosted project.

Discussion: https://github.com/getsentry/self-hosted/issues/2964#issuecomment-2116188032

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
