### PR TITLE
fix(sentry-admin): Do not wait for command finish to display output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,13 @@
 ## Testing
 
-Validate changes to the setup by running the integration test:
+### Running Tests with Pytest
 
-```shell
-./integration-test.sh
+We use pytest for running tests. To run the tests:
+
+1) Ensure that you are in the root directory of the project.
+2) Run the following command:
+```bash
+pytest
 ```
+
+This will automatically discover and run all test cases in the project.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-rerunfailures>=11.0
 pytest-sentry>=0.1.11
 httpx>=0.25.2
 beautifulsoup4>=4.7.1
+cryptography>=43.0.3

--- a/sentry-admin.sh
+++ b/sentry-admin.sh
@@ -22,8 +22,7 @@ on the host filesystem. Commands that write files should write them to the '/sen
 
 # Actual invocation that runs the command in the container.
 invocation() {
-  output=$($dc run -v "$VOLUME_MAPPING" --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web "$@" 2>&1)
-  echo "$output"
+  $dc run -v "$VOLUME_MAPPING" --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web "$@" 2>&1
 }
 
 # Function to modify lines starting with `Usage: sentry` to say `Usage: ./sentry-admin.sh` instead.


### PR DESCRIPTION
Currently sentry-admin.sh script saves the output of the command to a separate variable. This makes the command "freeze" if it requires any input from the user (like sentry-admin.sh restore). The change should provide the output directly to the shell.

Also changed contributing.md as it seemed outdated and updated requirements-dev.txt with the missing `cryptography` package.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
