### PR TITLE
feat: upgrade ClickHouse to version 24.3.5.47.altinitystable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
     build:
       context: ./clickhouse
       args:
-        BASE_IMAGE: "altinity/clickhouse-server:23.8.11.29.altinitystable"
+        BASE_IMAGE: "altinity/clickhouse-server:24.3.5.47.altinitystable"
     ulimits:
       nofile:
         soft: 262144

--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -29,7 +29,7 @@ if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
     $dc up -d clickhouse
     wait_for_clickhouse
     $dc down clickhouse
-    $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:24.3.5.47.altinitystable clickhouse
+    $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:23.8.11.29.altinitystable clickhouse
     $dc up -d clickhouse
     wait_for_clickhouse
   else

--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -17,7 +17,7 @@ if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
   # Wait for clickhouse
   wait_for_clickhouse
 
-  # In order to get to 23.8, we need to first upgrade go from 21.8 -> 22.8 -> 23.3 -> 23.8
+  # In order to get to 24.3, we need to first upgrade go from 21.8 -> 22.8 -> 23.3 -> 23.8 -> 24.3
   version=$($dc exec clickhouse clickhouse-client -q 'SELECT version()')
   if [[ "$version" == "21.8.13.1.altinitystable" || "$version" == "21.8.12.29.altinitydev.arm" ]]; then
     $dc down clickhouse
@@ -26,6 +26,10 @@ if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
     wait_for_clickhouse
     $dc down clickhouse
     $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:23.3.19.33.altinitystable clickhouse
+    $dc up -d clickhouse
+    wait_for_clickhouse
+    $dc down clickhouse
+    $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:24.3.5.47.altinitystable clickhouse
     $dc up -d clickhouse
     wait_for_clickhouse
   else

--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -9,6 +9,11 @@ function wait_for_clickhouse() {
   done
 }
 
+function get_clickhouse_version() {
+  $dc exec clickhouse clickhouse-client -q 'SELECT version()'
+}
+
+
 # First check to see if user is upgrading by checking for existing clickhouse volume
 if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
   # Start clickhouse if it is not already running
@@ -18,16 +23,24 @@ if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
   wait_for_clickhouse
 
   # In order to get to 24.3, we need to first upgrade go from 21.8 -> 22.8 -> 23.3 -> 23.8 -> 24.3
-  version=$($dc exec clickhouse clickhouse-client -q 'SELECT version()')
+  version=$(get_clickhouse_version)
   if [[ "$version" == "21.8.13.1.altinitystable" || "$version" == "21.8.12.29.altinitydev.arm" ]]; then
     $dc down clickhouse
     $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:22.8.15.25.altinitystable clickhouse
     $dc up -d clickhouse
     wait_for_clickhouse
+  fi
+
+  version=$(get_clickhouse_version)
+  if [[ "$version" == "22.8.15.25.altinitystable" || "$version" == "22.8.15.25.altinitydev.arm" ]]; then
     $dc down clickhouse
     $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:23.3.19.33.altinitystable clickhouse
     $dc up -d clickhouse
     wait_for_clickhouse
+  fi
+  
+  version=$(get_clickhouse_version)
+  if [[ "$version" == "23.3.19.33.altinitystable" || "$version" == "23.3.19.33.altinitydev.arm" ]]; then
     $dc down clickhouse
     $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:23.8.11.29.altinitystable clickhouse
     $dc up -d clickhouse

--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -13,7 +13,6 @@ function get_clickhouse_version() {
   $dc exec clickhouse clickhouse-client -q 'SELECT version()'
 }
 
-
 # First check to see if user is upgrading by checking for existing clickhouse volume
 if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
   # Start clickhouse if it is not already running
@@ -38,7 +37,7 @@ if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
     $dc up -d clickhouse
     wait_for_clickhouse
   fi
-  
+
   version=$(get_clickhouse_version)
   if [[ "$version" == "23.3.19.33.altinitystable" || "$version" == "23.3.19.33.altinitydev.arm" ]]; then
     $dc down clickhouse


### PR DESCRIPTION
#### Description:
This pull request introduces an upgrade of the ClickHouse service to version `24.3.5.47.altinitystable`. The upgrade process includes updating the Docker image and enhancing the upgrade script to support the new version.

#### Changes:
1. **Docker Compose Update:**
   - Updated the `BASE_IMAGE` in the `docker-compose.yml` file to `altinity/clickhouse-server:24.3.5.47.altinitystable`.

2. **Upgrade Script Enhancement:**
   - Extended the `upgrade-clickhouse.sh` script to include the upgrade path from `23.8` to `24.3.5.47.altinitystable`.

#### References:
- [ClickHouse Release Policy](https://clickhouse.com/docs/knowledgebase/production#how-to-choose-between-clickhouse-releases)

## Related Issues
- #3398

---

Please review the changes and provide feedback. If everything looks good, feel free to merge this pull request.
Thank you!

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
