### PR TITLE
add sentry/backup.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ data/
 sentry/sentry.conf.py
 sentry/config.yml
 sentry/*.bak
+sentry/backup.json
 sentry/enhance-image.sh
 sentry/requirements.txt
 relay/credentials.json


### PR DESCRIPTION


<!-- Describe your PR here. -->

The backup-method described in the [documentation](https://develop.sentry.dev/self-hosted/backup/#backup) `./scripts/backup.sh` creates a backup file at `sentry/backup.json` which should be ignored by git.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
