### PR TITLE
fix(redis): Actually use custom config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,9 @@ services:
       nofile:
         soft: 10032
         hard: 10032
+    command:
+      - redis-server
+      - /usr/local/etc/redis/redis.conf
   postgres:
     <<: *restart_policy
     # Using the same postgres version as Sentry dev for consistency purposes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,9 +117,7 @@ services:
       nofile:
         soft: 10032
         hard: 10032
-    command:
-      - redis-server
-      - /usr/local/etc/redis/redis.conf
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
   postgres:
     <<: *restart_policy
     # Using the same postgres version as Sentry dev for consistency purposes


### PR DESCRIPTION
Follow up to https://github.com/getsentry/self-hosted/pull/3427#issuecomment-2518128717 where we created and mounted a custom Redis config only to not use it :facepalm:
