### PR TITLE
fix(nginx): _assets should rewrite to _static/sentry/dist

### DIFF
--- a/_integration-test/test_run.py
+++ b/_integration-test/test_run.py
@@ -80,6 +80,14 @@ def test_initial_redirect():
     assert initial_auth_redirect.url == f"{SENTRY_TEST_HOST}/auth/login/sentry/"
 
 
+def test_asset_internal_rewrite():
+    """Tests whether we correctly map `/_assets/*` to `/_static/dist/sentry` as
+    we don't have a CDN setup in self-hosted."""
+    response = httpx.get(f"{SENTRY_TEST_HOST}/_assets/entrypoints/app.js")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/javascript"
+
+
 def test_login(client_login):
     client, login_response = client_login
     parser = BeautifulSoup(login_response.text, "html.parser")

--- a/_integration-test/test_run.py
+++ b/_integration-test/test_run.py
@@ -85,7 +85,7 @@ def test_asset_internal_rewrite():
     we don't have a CDN setup in self-hosted."""
     response = httpx.get(f"{SENTRY_TEST_HOST}/_assets/entrypoints/app.js")
     assert response.status_code == 200
-    assert response.headers["Content-Type"] == "application/javascript"
+    assert response.headers["Content-Type"] == "text/javascript"
 
 
 def test_login(client_login):

--- a/nginx.conf
+++ b/nginx.conf
@@ -98,6 +98,9 @@ http {
 		location / {
 			proxy_pass http://sentry;
 		}
+		location /_assets/ {
+			proxy_pass http://sentry/_static/dist/sentry/;
+		}
 		location /_static/ {
 			proxy_pass http://sentry;
 			proxy_hide_header Content-Disposition;

--- a/nginx.conf
+++ b/nginx.conf
@@ -100,6 +100,7 @@ http {
 		}
 		location /_assets/ {
 			proxy_pass http://sentry/_static/dist/sentry/;
+			proxy_hide_header Content-Disposition;
 		}
 		location /_static/ {
 			proxy_pass http://sentry;


### PR DESCRIPTION
Our default fallback, `_assets`, assumes we use a CDN which is not the case on self-hosted. This patch adds a stop-gap fix for front-end URLs asking for this path.

Should fix #3479 and #3470.
