### PR TITLE
chore(relay): provide opt-in max_memory_percent config as workaround for failing healthcheck

### DIFF
--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -11,3 +11,10 @@ processing:
     - {name: "message.max.bytes", value: 50000000} # 50MB
   redis: redis://redis:6379
   geoip_path: "/geoip/GeoLite2-City.mmdb"
+
+# In some cases, relay might fail to find out the actual machine memory
+# therefore it makes the healthcheck fail and events can't be submitted.
+# As a workaround, uncomment the following line:
+#
+# health:
+#  max_memory_percent: 1.0


### PR DESCRIPTION
See https://github.com/getsentry/self-hosted/issues/3330

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
