### PR TITLE
chore: clearer message for errors-only mode

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 COMPOSE_PROJECT_NAME=sentry-self-hosted
 # Set COMPOSE_PROFILES to "feature-complete" to enable all features
 # To enable errors monitoring only, set COMPOSE_PROFILES=errors-only
+# See https://develop.sentry.dev/self-hosted/experimental/errors-only/
 COMPOSE_PROFILES=feature-complete
 SENTRY_EVENT_RETENTION_DAYS=90
 # You can either use a port number or an IP:PORT combo for SENTRY_BIND

--- a/.env
+++ b/.env
@@ -1,4 +1,6 @@
 COMPOSE_PROJECT_NAME=sentry-self-hosted
+# Set COMPOSE_PROFILES to "feature-complete" to enable all features
+# To enable errors monitoring only, set COMPOSE_PROFILES=errors-only
 COMPOSE_PROFILES=feature-complete
 SENTRY_EVENT_RETENTION_DAYS=90
 # You can either use a port number or an IP:PORT combo for SENTRY_BIND

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -72,6 +72,18 @@ SENTRY_OPTIONS["system.event-retention-days"] = int(
     env("SENTRY_EVENT_RETENTION_DAYS", "90")
 )
 
+# Self-hosted Sentry infamously has a lot of Docker containers required to make
+# all the features work. Oftentimes, users don't use the full feature set that
+# requires all the containers. This is a way to enable only the error monitoring
+# feature which also reduces the amount of containers required to run Sentry.
+#
+# To make Sentry work with all features, set `COMPOSE_PROFILES` to `feature-complete`
+# in your `.env` file. To enable only the error monitoring feature, set
+# `COMPOSE_PROFILES` to `errors-only`.
+#
+# See https://develop.sentry.dev/self-hosted/experimental/errors-only/
+SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") != "feature-complete"
+
 #########
 # Redis #
 #########
@@ -372,10 +384,6 @@ CSP_REPORT_ONLY = True
 # your `.env` or `.env.custom` file. The files should only be a few KBs, and this might be useful
 # if you're using it directly like a CDN instead of using the loader script.
 JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
-
-
-# If you would like to use self-hosted Sentry with only errors enabled, please set this
-SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") != "feature-complete"
 
 #####################
 # Insights Settings #


### PR DESCRIPTION
Some people are missing the `COMPOSE_PROFILES` in their .env file, Hopefully this clears everything up (and make the `SENTRY_SELF_HOSTED_ERRORS_ONLY` variable stands out on the config file.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
