### PR TITLE
ref(geoip): Remove geoipupdate from compose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,7 @@ jobs:
 
       - name: Integration Test
         run: |
+          docker compose up --wait
           if [ "${{ matrix.compose_version }}" = "v2.19.0" ]; then
             pytest --reruns 3 --cov --junitxml=junit.xml _integration-test/ --customizations=${{ matrix.customizations }}
           else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,15 +207,6 @@ services:
       interval: 10s
       timeout: 10s
       retries: 30
-  geoipupdate:
-    image: "ghcr.io/maxmind/geoipupdate:v6.1.0"
-    # Override the entrypoint in order to avoid using envvars for config.
-    # Futz with settings so we can keep mmdb and conf in same dir on host
-    # (image looks for them in separate dirs by default).
-    entrypoint:
-      ["/usr/bin/geoipupdate", "-d", "/sentry", "-f", "/sentry/GeoIP.conf"]
-    volumes:
-      - "./geoip:/sentry"
   snuba-api:
     <<: *snuba_defaults
   # Kafka consumer responsible for feeding events into Clickhouse

--- a/install/geoip.sh
+++ b/install/geoip.sh
@@ -21,7 +21,7 @@ install_geoip() {
   else
     echo "IP address geolocation is configured for updates."
     echo "Updating IP address geolocation database ... "
-    if ! $dcr geoipupdate; then
+    if ! docker run --rm -v "./geoip:/sentry" --entrypoint '/usr/bin/geoipupdate' "ghcr.io/maxmind/geoipupdate:v6.1.0" "-d" "/sentry" "-f" "/sentry/GeoIP.conf"; then
       result='Error'
     fi
     echo "$result updating IP address geolocation database."

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -1,13 +1,7 @@
 echo "${_group}Setting up / migrating database ..."
 
 # Fixes https://github.com/getsentry/self-hosted/issues/2758, where a migration fails due to indexing issue
-$dc up -d postgres
-# Wait for postgres
-RETRIES=5
-until $dc exec postgres psql -U postgres -c "select 1" >/dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
-  echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
-  sleep 1
-done
+$dc up --wait postgres
 
 os=$($dc exec postgres cat /etc/os-release | grep 'ID=debian')
 if [[ -z $os ]]; then

--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -1,33 +1,19 @@
 echo "${_group}Upgrading Clickhouse ..."
 
-function wait_for_clickhouse() {
-  # Wait for clickhouse
-  RETRIES=30
-  until $dc ps clickhouse | grep 'healthy' || [ $RETRIES -eq 0 ]; do
-    echo "Waiting for clickhouse server, $((RETRIES--)) remaining attempts..."
-    sleep 1
-  done
-}
-
 # First check to see if user is upgrading by checking for existing clickhouse volume
 if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
   # Start clickhouse if it is not already running
-  $dc up -d clickhouse
-
-  # Wait for clickhouse
-  wait_for_clickhouse
+  $dc up --wait clickhouse
 
   # In order to get to 23.8, we need to first upgrade go from 21.8 -> 22.8 -> 23.3 -> 23.8
   version=$($dc exec clickhouse clickhouse-client -q 'SELECT version()')
   if [[ "$version" == "21.8.13.1.altinitystable" || "$version" == "21.8.12.29.altinitydev.arm" ]]; then
     $dc down clickhouse
     $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:22.8.15.25.altinitystable clickhouse
-    $dc up -d clickhouse
-    wait_for_clickhouse
+    $dc up --wait clickhouse
     $dc down clickhouse
     $dcb --build-arg BASE_IMAGE=altinity/clickhouse-server:23.3.19.33.altinitystable clickhouse
-    $dc up -d clickhouse
-    wait_for_clickhouse
+    $dc up --wait clickhouse
   else
     echo "Detected clickhouse version $version. Skipping upgrades!"
   fi

--- a/install/upgrade-postgres.sh
+++ b/install/upgrade-postgres.sh
@@ -20,7 +20,7 @@ if [[ -n "$(docker volume ls -q --filter name=sentry-postgres)" && "$(docker run
   docker volume rm sentry-postgres-new
   echo "Re-indexing due to glibc change, this may take a while..."
   echo "Starting up new PostgreSQL version"
-  $dc up -d postgres
+  $dc up --wait postgres
 
   # Wait for postgres
   RETRIES=5

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -2,7 +2,7 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
   echo "${_group}Waiting for Sentry to start ..."
 
   # Start the whole setup, except nginx and relay.
-  $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
+  $dc up --wait --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
   $dc restart relay
   $dc exec -T nginx nginx -s reload
 
@@ -10,7 +10,7 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
     -c 'while [[ "$(wget -T 1 -q -O- http://web:9000/_health/)" != "ok" ]]; do sleep 0.5; done'
 
   # Make sure everything is up. This should only touch relay and nginx
-  $dc up -d
+  $dc up --wait
 
   echo "${_endgroup}"
 else
@@ -20,9 +20,9 @@ else
   echo "You're all done! Run the following command to get Sentry running:"
   echo ""
   if [[ "${_ENV}" =~ ".env.custom" ]]; then
-    echo "  $dc_base --env-file ${_ENV} up -d"
+    echo "  $dc_base --env-file ${_ENV} up --wait"
   else
-    echo "  $dc_base up -d"
+    echo "  $dc_base up --wait"
   fi
   echo ""
   echo "-----------------------------------------------------------------"

--- a/sentry-admin.sh
+++ b/sentry-admin.sh
@@ -22,7 +22,7 @@ on the host filesystem. Commands that write files should write them to the '/sen
 
 # Actual invocation that runs the command in the container.
 invocation() {
-  $dc run -v "$VOLUME_MAPPING" --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web "$@" 2>&1
+  $dcr --quiet-pull -v "$VOLUME_MAPPING" -T -e SENTRY_LOG_LEVEL=CRITICAL web "$@" 2>&1
 }
 
 # Function to modify lines starting with `Usage: sentry` to say `Usage: ./sentry-admin.sh` instead.


### PR DESCRIPTION
`geoipupdate` is not used by any other service nor it is needed for any
service to run. Moreover, it is a one-shot command, causing
`docker compose up --wait` to fail when it exits with a non-zero status.
This happens when one has not yet set up their credentials and they may
choose to never do this.

This PR removes `geoipupdate` from the `docker-compose.yml` file and
moves the command directly into the geoip related script. One may run
this whenever they want to update their GeoIP database.

This PR needs an accompanying docs change.

It also has the side-effect of making integration tests slightly faster (due to the initial `docker compose up --wait`), and more reliable as we used to rely on the implicit `docker compose run web` from the `sentry_admin` test. This also skewed the test run duration of `sentry_admin` test by including the system startup time there.
