### PR TITLE
ref(snuba): Combine bootstrap & migrate for faster bootstrap

### DIFF
--- a/install/bootstrap-snuba.sh
+++ b/install/bootstrap-snuba.sh
@@ -1,6 +1,5 @@
 echo "${_group}Bootstrapping and migrating Snuba ..."
 
-$dcr snuba-api bootstrap --no-migrate --force
-$dcr snuba-api migrations migrate --force
+$dcr snuba-api bootstrap --force
 
 echo "${_endgroup}"


### PR DESCRIPTION
I think we split these actions in the past due to some lack of options for them to work together properly. Right now looks like `bootstrap` would automatically migrate and propagates the `force` flag.
