### PR TITLE
chore: Remove everything zookeeper

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,6 @@ source install/check-minimum-requirements.sh
 # in order to determine whether or not the clickhouse version needs to be upgraded.
 source install/upgrade-clickhouse.sh
 source install/turn-things-off.sh
-source install/update-docker-volume-permissions.sh
 source install/create-docker-volumes.sh
 source install/ensure-files-from-examples.sh
 source install/check-memcached-backend.sh

--- a/install/update-docker-volume-permissions.sh
+++ b/install/update-docker-volume-permissions.sh
@@ -1,9 +1,0 @@
-echo "${_group}Ensuring Kafka and Zookeeper volumes have correct permissions ..."
-
-# Only supporting platforms on linux x86 platforms and not apple silicon. I'm assuming that folks using apple silicon are doing it for dev purposes and it's difficult
-# to change permissions of docker volumes since it is run in a VM.
-if [[ -n "$(docker volume ls -q -f name=sentry-zookeeper)" && -n "$(docker volume ls -q -f name=sentry-kafka)" ]]; then
-  docker run --rm -v "sentry-zookeeper:/sentry-zookeeper-data" -v "sentry-kafka:/sentry-kafka-data" -v "${COMPOSE_PROJECT_NAME}_sentry-zookeeper-log:/sentry-zookeeper-log-data" busybox chmod -R a+w /sentry-zookeeper-data /sentry-kafka-data /sentry-zookeeper-log-data
-fi
-
-echo "${_endgroup}"

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -28,8 +28,3 @@ else
   echo "-----------------------------------------------------------------"
   echo ""
 fi
-
-# TODO(getsentry/self-hosted#2489)
-if docker volume ls | grep -qw sentry-zookeeper; then
-  docker volume rm sentry-zookeeper
-fi


### PR DESCRIPTION
Since the last hard stop is at 24.8.0, which uses zookeeper-less kafka (kRAFT), this can be safely removed

Closes #2489