### PR TITLE
ci: Less volatile cache keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,19 +63,19 @@ jobs:
           sudo chmod o+x /var/lib/docker
           sudo chmod -R o+rwx /var/lib/docker/volumes
           source .env
-          SENTRY_IMAGE_SHA=$(docker buildx imagetools inspect $SENTRY_IMAGE --format "{{println .Manifest.Digest}}")
-          echo "SENTRY_IMAGE_SHA=$SENTRY_IMAGE_SHA" >> $GITHUB_OUTPUT
-          SNUBA_IMAGE_SHA=$(docker buildx imagetools inspect $SNUBA_IMAGE --format "{{println .Manifest.Digest}}")
-          echo "SNUBA_IMAGE_SHA=$SNUBA_IMAGE_SHA" >> $GITHUB_OUTPUT
+          SENTRY_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SENTRY_IMAGE -c 'ls -Rv1rpq src/sentry/migrations/' | md5sum | cut -d ' ' -f 1)
+          echo "SENTRY_MIGRATIONS_MD5=$SENTRY_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
+          SNUBA_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SNUBA_IMAGE -c 'ls -Rv1rpq snuba/snuba_migrations/**/*.py' | md5sum | cut -d ' ' -f 1)
+          echo "SNUBA_MIGRATIONS_MD5=$SNUBA_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
 
       - name: Restore DB Volumes Cache
         id: restore_cache
         uses: actions/cache/restore@v4
         with:
-          key: db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
+          key: db-volumes-v5-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}
           restore-keys: |
-            db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
-            db-volumes-v4-
+            db-volumes-v5-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}
+            db-volumes-v5-
           path: |
             /var/lib/docker/volumes/sentry-postgres/_data
             /var/lib/docker/volumes/sentry-clickhouse/_data

--- a/action.yaml
+++ b/action.yaml
@@ -62,6 +62,8 @@ runs:
         sudo chmod o+x /var/lib/docker
         sudo chmod -R o+rwx /var/lib/docker/volumes
         source ${{ github.action_path }}/.env
+        # See https://explainshell.com/explain?cmd=ls%20-Rv1rpq
+        # for that long `ls` command
         SENTRY_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SENTRY_IMAGE -c 'ls -Rv1rpq src/sentry/migrations/' | md5sum | cut -d ' ' -f 1)
         echo "SENTRY_MIGRATIONS_MD5=$SENTRY_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
         SNUBA_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SNUBA_IMAGE -c 'ls -Rv1rpq snuba/snuba_migrations/**/*.py' | md5sum | cut -d ' ' -f 1)

--- a/action.yaml
+++ b/action.yaml
@@ -62,19 +62,19 @@ runs:
         sudo chmod o+x /var/lib/docker
         sudo chmod -R o+rwx /var/lib/docker/volumes
         source ${{ github.action_path }}/.env
-        SENTRY_IMAGE_SHA=$(docker buildx imagetools inspect $SENTRY_IMAGE --format "{{println .Manifest.Digest}}")
-        echo "SENTRY_IMAGE_SHA=$SENTRY_IMAGE_SHA" >> $GITHUB_OUTPUT
-        SNUBA_IMAGE_SHA=$(docker buildx imagetools inspect $SNUBA_IMAGE --format "{{println .Manifest.Digest}}")
-        echo "SNUBA_IMAGE_SHA=$SNUBA_IMAGE_SHA" >> $GITHUB_OUTPUT
+        SENTRY_MIGRATIONS_MD5=$docker run --rm --entrypoint bash $SENTRY_IMAGE -c 'ls -Rv1rpq src/sentry/migrations/' | md5sum | cut -d ' ' -f 1)
+        echo "SENTRY_MIGRATIONS_MD5=$SENTRY_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
+        SNUBA_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SNUBA_IMAGE -c 'ls -Rv1rpq snuba/snuba_migrations/**/*.py' | md5sum | cut -d ' ' -f 1       )
+        echo "SNUBA_MIGRATIONS_MD5=$SNUBA_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
 
     - name: Restore DB Volumes Cache
       id: restore_cache
       uses: actions/cache/restore@v4
       with:
-        key: db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
+        key: db-volumes-v5-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}
         restore-keys: |
-          db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
-          db-volumes-v4-
+          db-volumes-v5-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}
+          db-volumes-v5-
         path: |
           /var/lib/docker/volumes/sentry-postgres/_data
           /var/lib/docker/volumes/sentry-clickhouse/_data

--- a/action.yaml
+++ b/action.yaml
@@ -62,9 +62,9 @@ runs:
         sudo chmod o+x /var/lib/docker
         sudo chmod -R o+rwx /var/lib/docker/volumes
         source ${{ github.action_path }}/.env
-        SENTRY_MIGRATIONS_MD5=$docker run --rm --entrypoint bash $SENTRY_IMAGE -c 'ls -Rv1rpq src/sentry/migrations/' | md5sum | cut -d ' ' -f 1)
+        SENTRY_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SENTRY_IMAGE -c 'ls -Rv1rpq src/sentry/migrations/' | md5sum | cut -d ' ' -f 1)
         echo "SENTRY_MIGRATIONS_MD5=$SENTRY_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
-        SNUBA_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SNUBA_IMAGE -c 'ls -Rv1rpq snuba/snuba_migrations/**/*.py' | md5sum | cut -d ' ' -f 1       )
+        SNUBA_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SNUBA_IMAGE -c 'ls -Rv1rpq snuba/snuba_migrations/**/*.py' | md5sum | cut -d ' ' -f 1)
         echo "SNUBA_MIGRATIONS_MD5=$SNUBA_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
 
     - name: Restore DB Volumes Cache


### PR DESCRIPTION
Instead of using direct image hashes, only use hashes from migrations folders for each respective image for cache key generation. Should increase cache hit rate significantly as we don't have migrations much.

Also swaps the key order from `sentry-snuba` to `snuba-senry` assuming Snuba has less frequent migration additions.