### PR TITLE
byk/ref/use docker cache actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,10 +69,10 @@ jobs:
         id: restore_cache
         uses: BYK/docker-volume-cache-action/restore@main
         with:
-          key: db-volumes-v4-beta-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
+          key: db-volumes-v4-b.1-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
           restore-keys: |
-            db-volumes-v4-beta-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
-            db-volumes-v4-beta-
+            db-volumes-v4-b.1-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
+            db-volumes-v4-b.1-
           volumes: |
             sentry-postgres
             sentry-clickhouse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,6 @@ jobs:
         env:
           SKIP_DB_MIGRATIONS: ${{ steps.restore_cache.outputs.cache-hit == 'true' && '1' || '' }}
         run: |
-          # This is for the cache restore on Kafka to work in older releases
-          docker run --rm -v "sentry-kafka:/data" busybox chown -R 1000:1000 /data
           ./install.sh
 
       - name: Save DB Volumes Cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Restore DB Volumes Cache
         id: restore_cache
-        uses: BYK/docker-volume-cache-action/restore@main
+        uses: BYK/docker-volume-cache-action/restore@be89365902126f508dcae387a32ec3712df6b1cd
         with:
           key: db-volumes-v6-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}
           restore-keys: |
@@ -90,7 +90,7 @@ jobs:
 
       - name: Save DB Volumes Cache
         if: steps.restore_cache.outputs.cache-hit != 'true'
-        uses: BYK/docker-volume-cache-action/save@main
+        uses: BYK/docker-volume-cache-action/save@be89365902126f508dcae387a32ec3712df6b1cd
         with:
           key: ${{ steps.restore_cache.outputs.cache-primary-key }}
           volumes: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
           # This is to compensate for a bug in upgrade-clickhouse where
           # if we have sentry-clickhouse volume without the rest, it fails
           # We may get sentry-clickhouse from the cache step above
-          install/create-docker-volumes.sh
+          source install/create-docker-volumes.sh
           ./install.sh
 
       - name: Save DB Volumes Cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,22 +56,13 @@ jobs:
           sudo curl -L https://github.com/docker/compose/releases/download/v2.26.0/docker-compose-`uname -s`-`uname -m` -o "/usr/local/lib/docker/cli-plugins/docker-compose"
           sudo chmod +x "/usr/local/lib/docker/cli-plugins/docker-compose"
 
-      - name: Compute Docker Volume Cache Key
-        id: cache_key
-        run: |
-          source .env
-          SENTRY_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SENTRY_IMAGE -c 'ls -Rv1rpq src/sentry/migrations/' | md5sum | cut -d ' ' -f 1)
-          echo "SENTRY_MIGRATIONS_MD5=$SENTRY_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
-          SNUBA_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SNUBA_IMAGE -c 'ls -Rv1rpq snuba/snuba_migrations/**/*.py' | md5sum | cut -d ' ' -f 1)
-          echo "SNUBA_MIGRATIONS_MD5=$SNUBA_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
-
       - name: Restore DB Volumes Cache
         id: restore_cache
         uses: BYK/docker-volume-cache-action/restore@be89365902126f508dcae387a32ec3712df6b1cd
         with:
-          key: db-volumes-v6-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}
+          key: db-volumes-v6-${{ env.LATEST_TAG }}
           restore-keys: |
-            db-volumes-v6-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}
+            db-volumes-v6-${{ env.LATEST_TAG }}
             db-volumes-v6-
           volumes: |
             sentry-postgres
@@ -80,7 +71,8 @@ jobs:
 
       - name: Install ${{ env.LATEST_TAG }}
         env:
-          SKIP_DB_MIGRATIONS: ${{ steps.restore_cache.outputs.cache-hit == 'true' && '1' || '' }}
+          SKIP_SENTRY_MIGRATIONS: ${{ steps.restore_cache.outputs.cache-hit == 'true' && '1' || '' }}
+          SKIP_SNUBA_MIGRATIONS: ${{ steps.restore_cache.outputs.cache-hit == 'true' && '1' || '' }}
         run: |
           # This is to compensate for a bug in upgrade-clickhouse where
           # if we have sentry-clickhouse volume without the rest, it fails

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,10 +69,10 @@ jobs:
         id: restore_cache
         uses: BYK/docker-volume-cache-action/restore@main
         with:
-          key: db-volumes-v5-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
+          key: db-volumes-v4-beta-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
           restore-keys: |
-            db-volumes-v5-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
-            db-volumes-v5-
+            db-volumes-v4-beta-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
+            db-volumes-v4-beta-
           volumes: |
             sentry-postgres
             sentry-clickhouse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,10 @@ jobs:
         env:
           SKIP_DB_MIGRATIONS: ${{ steps.restore_cache.outputs.cache-hit == 'true' && '1' || '' }}
         run: |
+          # This is to compensate for a bug in upgrade-clickhouse where
+          # if we have sentry-clickhouse volume without the rest, it fails
+          # We may get sentry-clickhouse from the cache step above
+          install/create-docker-volumes.sh
           ./install.sh
 
       - name: Save DB Volumes Cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,12 +56,9 @@ jobs:
           sudo curl -L https://github.com/docker/compose/releases/download/v2.26.0/docker-compose-`uname -s`-`uname -m` -o "/usr/local/lib/docker/cli-plugins/docker-compose"
           sudo chmod +x "/usr/local/lib/docker/cli-plugins/docker-compose"
 
-      - name: Prepare Docker Volume Caching
+      - name: Compute Docker Volume Cache Key
         id: cache_key
         run: |
-          # Set permissions for docker volumes so we can cache and restore
-          sudo chmod o+x /var/lib/docker
-          sudo chmod -R o+rwx /var/lib/docker/volumes
           source .env
           SENTRY_IMAGE_SHA=$(docker buildx imagetools inspect $SENTRY_IMAGE --format "{{println .Manifest.Digest}}")
           echo "SENTRY_IMAGE_SHA=$SENTRY_IMAGE_SHA" >> $GITHUB_OUTPUT
@@ -70,16 +67,16 @@ jobs:
 
       - name: Restore DB Volumes Cache
         id: restore_cache
-        uses: actions/cache/restore@v4
+        uses: BYK/docker-volume-cache-action/restore@main
         with:
           key: db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
           restore-keys: |
             db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
             db-volumes-v4-
-          path: |
-            /var/lib/docker/volumes/sentry-postgres/_data
-            /var/lib/docker/volumes/sentry-clickhouse/_data
-            /var/lib/docker/volumes/sentry-kafka/_data
+          volumes: |
+            sentry-postgres
+            sentry-clickhouse
+            sentry-kafka
 
       - name: Install ${{ env.LATEST_TAG }}
         env:
@@ -89,25 +86,15 @@ jobs:
           docker run --rm -v "sentry-kafka:/data" busybox chown -R 1000:1000 /data
           ./install.sh
 
-      - name: Prepare Docker Volume Caching
-        run: |
-          # Set permissions for docker volumes so we can cache and restore
-          # We need these for the backup/restore test snapshotting too
-          sudo chmod o+x /var/lib/docker
-          sudo chmod -R o+rx /var/lib/docker/volumes
-          # Set tar ownership for it to be able to read
-          # From: https://github.com/actions/toolkit/issues/946#issuecomment-1726311681
-          sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-
       - name: Save DB Volumes Cache
         if: steps.restore_cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: BYK/docker-volume-cache-action/save@main
         with:
           key: ${{ steps.restore_cache.outputs.cache-primary-key }}
-          path: |
-            /var/lib/docker/volumes/sentry-postgres/_data
-            /var/lib/docker/volumes/sentry-clickhouse/_data
-            /var/lib/docker/volumes/sentry-kafka/_data
+          volumes: |
+            sentry-postgres
+            sentry-clickhouse
+            sentry-kafka
 
       - name: Checkout current ref
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,10 +69,10 @@ jobs:
         id: restore_cache
         uses: BYK/docker-volume-cache-action/restore@main
         with:
-          key: db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
+          key: db-volumes-v5-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
           restore-keys: |
-            db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
-            db-volumes-v4-
+            db-volumes-v5-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
+            db-volumes-v5-
           volumes: |
             sentry-postgres
             sentry-clickhouse

--- a/action.yaml
+++ b/action.yaml
@@ -54,34 +54,58 @@ runs:
         sudo curl -L https://github.com/docker/compose/releases/download/${{ env.COMPOSE_VERSION }}/docker-compose-`uname -s`-`uname -m` -o "${{ env.COMPOSE_PATH }}/docker-compose"
         sudo chmod +x "${{ env.COMPOSE_PATH }}/docker-compose"
 
-    - name: Compute Docker Volume Cache Key
+    - name: Compute Docker Volume Cache Keys
       id: cache_key
       shell: bash
       run: |
         source ${{ github.action_path }}/.env
         # See https://explainshell.com/explain?cmd=ls%20-Rv1rpq
         # for that long `ls` command
-        SENTRY_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SENTRY_IMAGE -c 'ls -Rv1rpq src/sentry/migrations/' | md5sum | cut -d ' ' -f 1)
+        SENTRY_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SENTRY_IMAGE -c '{ ls -Rv1rpq src/sentry/migrations/; sed -n "/KAFKA_TOPIC_TO_CLUSTER/,/}/p" src/sentry/conf/server.py; }' | md5sum | cut -d ' ' -f 1)
         echo "SENTRY_MIGRATIONS_MD5=$SENTRY_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
-        SNUBA_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SNUBA_IMAGE -c 'ls -Rv1rpq snuba/snuba_migrations/**/*.py' | md5sum | cut -d ' ' -f 1)
+        SNUBA_MIGRATIONS_MD5=$(docker run --rm --entrypoint bash $SNUBA_IMAGE -c '{ ls -Rv1rpq snuba/snuba_migrations/**/*.py; sed -n "/^class Topic(Enum):/,/\\n\\n/p" snuba/utils/streams/topics.py; }' | md5sum | cut -d ' ' -f 1)
         echo "SNUBA_MIGRATIONS_MD5=$SNUBA_MIGRATIONS_MD5" >> $GITHUB_OUTPUT
 
-    - name: Restore DB Volumes Cache
-      id: restore_cache
+    - name: Restore Sentry Volume Cache
+      id: restore_cache_sentry
       uses: BYK/docker-volume-cache-action/restore@be89365902126f508dcae387a32ec3712df6b1cd
       with:
-        key: db-volumes-v6-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}
+        key: db-volumes-sentry-v1-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}
         restore-keys: |
-          db-volumes-v6-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}
-          db-volumes-v6-
+          db-volumes-sentry-v1-
         volumes: |
           sentry-postgres
+
+    - name: Restore Snuba Volume Cache
+      id: restore_cache_snuba
+      uses: BYK/docker-volume-cache-action/restore@be89365902126f508dcae387a32ec3712df6b1cd
+      with:
+        key: db-volumes-snuba-v1-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}
+        restore-keys: |
+          db-volumes-snuba-v1-
+        volumes: |
           sentry-clickhouse
+
+    - name: Restore Kafka Volume Cache
+      id: restore_cache_kafka
+      uses: BYK/docker-volume-cache-action/restore@be89365902126f508dcae387a32ec3712df6b1cd
+      with:
+        key: db-volumes-kafka-v1-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}
+        restore-keys: |
+          db-volumes-kafka-v1-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}
+          db-volumes-kafka-v1-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}-
+          db-volumes-kafka-v1-
+        volumes: |
           sentry-kafka
 
     - name: Install self-hosted
       env:
-        SKIP_DB_MIGRATIONS: ${{ steps.restore_cache.outputs.cache-hit == 'true' && '1' || '' }}
+        # Note that cache keys for Sentry and Snuba have their respective Kafka configs built into them
+        # and the Kafka volume cache is comprises both keys. This way we can omit the Kafka cache hit
+        # in here to still avoid running Sentry or Snuba migrations if only one of their Kafka config has
+        # changed. Heats up your head a bit but if you think about it, it makes sense.
+        SKIP_SENTRY_MIGRATIONS: ${{ steps.restore_cache_sentry.outputs.cache-hit == 'true' && '1' || '' }}
+        SKIP_SNUBA_MIGRATIONS: ${{ steps.restore_cache_snuba.outputs.cache-hit == 'true' && '1' || '' }}
       shell: bash
       run: |
         cd ${{ github.action_path }}
@@ -97,14 +121,28 @@ runs:
 
         ./install.sh --no-report-self-hosted-issues --skip-commit-check
 
-    - name: Save DB Volumes Cache
-      if: steps.restore_cache.outputs.cache-hit != 'true'
+    - name: Save Sentry Volume Cache
+      if: steps.restore_cache_sentry.outputs.cache-hit != 'true'
       uses: BYK/docker-volume-cache-action/save@be89365902126f508dcae387a32ec3712df6b1cd
       with:
-        key: ${{ steps.restore_cache.outputs.cache-primary-key }}
+        key: ${{ steps.restore_cache_sentry.outputs.cache-primary-key }}
         volumes: |
           sentry-postgres
+
+    - name: Save Snuba Volume Cache
+      if: steps.restore_cache_snuba.outputs.cache-hit != 'true'
+      uses: BYK/docker-volume-cache-action/save@be89365902126f508dcae387a32ec3712df6b1cd
+      with:
+        key: ${{ steps.restore_cache_snuba.outputs.cache-primary-key }}
+        volumes: |
           sentry-clickhouse
+
+    - name: Save Kafka Volume Cache
+      if: steps.restore_cache_kafka.outputs.cache-hit != 'true'
+      uses: BYK/docker-volume-cache-action/save@be89365902126f508dcae387a32ec3712df6b1cd
+      with:
+        key: ${{ steps.restore_cache_kafka.outputs.cache-primary-key }}
+        volumes: |
           sentry-kafka
 
     - name: Integration Test

--- a/action.yaml
+++ b/action.yaml
@@ -54,13 +54,10 @@ runs:
         sudo curl -L https://github.com/docker/compose/releases/download/${{ env.COMPOSE_VERSION }}/docker-compose-`uname -s`-`uname -m` -o "${{ env.COMPOSE_PATH }}/docker-compose"
         sudo chmod +x "${{ env.COMPOSE_PATH }}/docker-compose"
 
-    - name: Prepare Docker Volume Caching
+    - name: Compute Docker Volume Cache Key
       id: cache_key
       shell: bash
       run: |
-        # Set permissions for docker volumes so we can cache and restore
-        sudo chmod o+x /var/lib/docker
-        sudo chmod -R o+rwx /var/lib/docker/volumes
         source ${{ github.action_path }}/.env
         SENTRY_IMAGE_SHA=$(docker buildx imagetools inspect $SENTRY_IMAGE --format "{{println .Manifest.Digest}}")
         echo "SENTRY_IMAGE_SHA=$SENTRY_IMAGE_SHA" >> $GITHUB_OUTPUT
@@ -69,16 +66,16 @@ runs:
 
     - name: Restore DB Volumes Cache
       id: restore_cache
-      uses: actions/cache/restore@v4
+      uses: BYK/docker-volume-cache-action/restore@main
       with:
         key: db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
         restore-keys: |
           db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
           db-volumes-v4-
-        path: |
-          /var/lib/docker/volumes/sentry-postgres/_data
-          /var/lib/docker/volumes/sentry-clickhouse/_data
-          /var/lib/docker/volumes/sentry-kafka/_data
+        volumes: |
+          sentry-postgres
+          sentry-clickhouse
+          sentry-kafka
 
     - name: Install self-hosted
       env:
@@ -100,31 +97,20 @@ runs:
 
         ./install.sh --no-report-self-hosted-issues --skip-commit-check
 
-    - name: Prepare Docker Volume Caching
-      shell: bash
-      run: |
-        # Set permissions for docker volumes so we can cache and restore
-        # We need these for the backup/restore test snapshotting too
-        sudo chmod o+x /var/lib/docker
-        sudo chmod -R o+rx /var/lib/docker/volumes
-        # Set tar ownership for it to be able to read
-        # From: https://github.com/actions/toolkit/issues/946#issuecomment-1726311681
-        sudo chown root /usr/bin/tar && sudo chmod u+s /usr/bin/tar
-        sudo chown root /usr/bin/rsync && sudo chmod u+s /usr/bin/rsync
-
     - name: Save DB Volumes Cache
       if: steps.restore_cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: BYK/docker-volume-cache-action/save@main
       with:
         key: ${{ steps.restore_cache.outputs.cache-primary-key }}
-        path: |
-          /var/lib/docker/volumes/sentry-postgres/_data
-          /var/lib/docker/volumes/sentry-clickhouse/_data
-          /var/lib/docker/volumes/sentry-kafka/_data
+        volumes: |
+          sentry-postgres
+          sentry-clickhouse
+          sentry-kafka
 
     - name: Integration Test
       shell: bash
       run: |
+        sudo chown root /usr/bin/rsync && sudo chmod u+s /usr/bin/rsync
         rsync -aW --no-compress --mkpath \
           /var/lib/docker/volumes/sentry-postgres \
           /var/lib/docker/volumes/sentry-clickhouse \

--- a/action.yaml
+++ b/action.yaml
@@ -68,10 +68,10 @@ runs:
       id: restore_cache
       uses: BYK/docker-volume-cache-action/restore@main
       with:
-        key: db-volumes-v5-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
+        key: db-volumes-v4-beta-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
         restore-keys: |
-          db-volumes-v5-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
-          db-volumes-v5-
+          db-volumes-v4-beta-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
+          db-volumes-v4-beta-
         volumes: |
           sentry-postgres
           sentry-clickhouse

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         image_var=$(echo ${{ inputs.project_name }}_IMAGE | tr '[:lower:]' '[:upper:]')
-        echo "${image_var}=${{ inputs.image_url }}" >> ${{ github.action_path }}/.env
+        echo "${image_var}=${{ inputs.image_url }}" >> ${{ github.action_path }}.env
 
     - name: Setup dev environment
       shell: bash
@@ -58,7 +58,7 @@ runs:
       id: cache_key
       shell: bash
       run: |
-        source ${{ github.action_path }}/.env
+        source ${{ github.action_path }}.env
         SENTRY_IMAGE_SHA=$(docker buildx imagetools inspect $SENTRY_IMAGE --format "{{println .Manifest.Digest}}")
         echo "SENTRY_IMAGE_SHA=$SENTRY_IMAGE_SHA" >> $GITHUB_OUTPUT
         SNUBA_IMAGE_SHA=$(docker buildx imagetools inspect $SNUBA_IMAGE --format "{{println .Manifest.Digest}}")

--- a/action.yaml
+++ b/action.yaml
@@ -83,8 +83,6 @@ runs:
       shell: bash
       run: |
         cd ${{ github.action_path }}
-        # This is for the cache restore on Kafka to work in older releases
-        docker run --rm -v "sentry-kafka:/data" busybox chown -R 1000:1000 /data
         # Add some customizations to test that path
         cat <<EOT >> sentry/enhance-image.sh
         #!/bin/bash
@@ -98,7 +96,7 @@ runs:
         ./install.sh --no-report-self-hosted-issues --skip-commit-check
 
     - name: Save DB Volumes Cache
-      # if: steps.restore_cache.outputs.cache-hit != 'true'
+      if: steps.restore_cache.outputs.cache-hit != 'true'
       uses: BYK/docker-volume-cache-action/save@main
       with:
         key: ${{ steps.restore_cache.outputs.cache-primary-key }}

--- a/action.yaml
+++ b/action.yaml
@@ -68,10 +68,10 @@ runs:
       id: restore_cache
       uses: BYK/docker-volume-cache-action/restore@main
       with:
-        key: db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
+        key: db-volumes-v5-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
         restore-keys: |
-          db-volumes-v4-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
-          db-volumes-v4-
+          db-volumes-v5-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
+          db-volumes-v5-
         volumes: |
           sentry-postgres
           sentry-clickhouse

--- a/action.yaml
+++ b/action.yaml
@@ -68,10 +68,10 @@ runs:
       id: restore_cache
       uses: BYK/docker-volume-cache-action/restore@main
       with:
-        key: db-volumes-v4-beta-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
+        key: db-volumes-v4-b.1-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}-${{ steps.cache_key.outputs.SNUBA_IMAGE_SHA }}
         restore-keys: |
-          db-volumes-v4-beta-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
-          db-volumes-v4-beta-
+          db-volumes-v4-b.1-${{ steps.cache_key.outputs.SENTRY_IMAGE_SHA }}
+          db-volumes-v4-b.1-
         volumes: |
           sentry-postgres
           sentry-clickhouse

--- a/action.yaml
+++ b/action.yaml
@@ -83,8 +83,6 @@ runs:
       shell: bash
       run: |
         cd ${{ github.action_path }}
-        # This is for the cache restore on Kafka to work in older releases
-        docker run --rm -v "sentry-kafka:/data" busybox chown -R 1000:1000 /data
         # Add some customizations to test that path
         cat <<EOT >> sentry/enhance-image.sh
         #!/bin/bash

--- a/action.yaml
+++ b/action.yaml
@@ -68,7 +68,7 @@ runs:
 
     - name: Restore DB Volumes Cache
       id: restore_cache
-      uses: BYK/docker-volume-cache-action/restore@main
+      uses: BYK/docker-volume-cache-action/restore@be89365902126f508dcae387a32ec3712df6b1cd
       with:
         key: db-volumes-v6-${{ steps.cache_key.outputs.SNUBA_MIGRATIONS_MD5 }}-${{ steps.cache_key.outputs.SENTRY_MIGRATIONS_MD5 }}
         restore-keys: |
@@ -99,7 +99,7 @@ runs:
 
     - name: Save DB Volumes Cache
       if: steps.restore_cache.outputs.cache-hit != 'true'
-      uses: BYK/docker-volume-cache-action/save@main
+      uses: BYK/docker-volume-cache-action/save@be89365902126f508dcae387a32ec3712df6b1cd
       with:
         key: ${{ steps.restore_cache.outputs.cache-primary-key }}
         volumes: |

--- a/action.yaml
+++ b/action.yaml
@@ -83,6 +83,8 @@ runs:
       shell: bash
       run: |
         cd ${{ github.action_path }}
+        # This is for the cache restore on Kafka to work in older releases
+        docker run --rm -v "sentry-kafka:/data" busybox chown -R 1000:1000 /data
         # Add some customizations to test that path
         cat <<EOT >> sentry/enhance-image.sh
         #!/bin/bash
@@ -96,7 +98,7 @@ runs:
         ./install.sh --no-report-self-hosted-issues --skip-commit-check
 
     - name: Save DB Volumes Cache
-      if: steps.restore_cache.outputs.cache-hit != 'true'
+      # if: steps.restore_cache.outputs.cache-hit != 'true'
       uses: BYK/docker-volume-cache-action/save@main
       with:
         key: ${{ steps.restore_cache.outputs.cache-primary-key }}

--- a/install/bootstrap-snuba.sh
+++ b/install/bootstrap-snuba.sh
@@ -1,9 +1,9 @@
 echo "${_group}Bootstrapping and migrating Snuba ..."
 
-if [[ -z "${SKIP_DB_MIGRATIONS:-}" ]]; then
+if [[ -z "${SKIP_SNUBA_MIGRATIONS:-}" ]]; then
   $dcr snuba-api bootstrap --force
 else
-  echo "Skipped DB migrations due to SKIP_DB_MIGRATIONS=$SKIP_DB_MIGRATIONS"
+  echo "Skipped DB migrations due to SKIP_SNUBA_MIGRATIONS=$SKIP_SNUBA_MIGRATIONS"
 fi
 
 echo "${_endgroup}"

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -1,6 +1,6 @@
 echo "${_group}Setting up / migrating database ..."
 
-if [[ -z "${SKIP_DB_MIGRATIONS:-}" ]]; then
+if [[ -z "${SKIP_SENTRY_MIGRATIONS:-}" ]]; then
   # Fixes https://github.com/getsentry/self-hosted/issues/2758, where a migration fails due to indexing issue
   $dc up --wait postgres
 
@@ -31,6 +31,6 @@ with connection.cursor() as cursor:
     $dcr web upgrade --create-kafka-topics
   fi
 else
-  echo "Skipped DB migrations due to SKIP_DB_MIGRATIONS=$SKIP_DB_MIGRATIONS"
+  echo "Skipped DB migrations due to SKIP_SENTRY_MIGRATIONS=$SKIP_SENTRY_MIGRATIONS"
 fi
 echo "${_endgroup}"

--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -1,7 +1,7 @@
 echo "${_group}Upgrading Clickhouse ..."
 
 # First check to see if user is upgrading by checking for existing clickhouse volume
-if [[ -n "$(docker volume ls -q --filter name=sentry-clickhouse)" ]]; then
+if docker compose ps -a | grep -q clickhouse; then
   # Start clickhouse if it is not already running
   $dc up --wait clickhouse
 


### PR DESCRIPTION
- **ci: Use generic Docker volume cache action**
- **remove kafka perms workaround too**
- **better clickhouse check**
- **avoid double fw slash**
- **try to fix the upgrade test**
- **temp fix for kafka**
- **use the source luke**
- **Revert "temp fix for kafka"**
- **Reapply "temp fix for kafka"**
- **Revert "Reapply "temp fix for kafka""**
- **Reapply "Reapply "temp fix for kafka""**
- **Revert "Reapply "Reapply "temp fix for kafka"""**
- **try bumping cache key version**
- **bump cache version everywhere**
- **change cache version again, use the newest tar hack**
- **try with fresh cache**
- **use and pin to stable release git sha**
- **ci: Even better cache keys and granular caching**
