### PR TITLE
fix: Use correct path for get compose action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ runs:
         fi
 
     - name: Get Compose
-      uses: ./get-compose-action
+      uses: ${{ github.action_path }}/get-compose-action
 
     - name: Compute Docker Volume Cache Keys
       id: cache_key

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ runs:
         fi
 
     - name: Get Compose
-      uses: ${{ github.action_path }}/get-compose-action
+      uses: getsentry/self-hosted/get-compose-action@master
 
     - name: Compute Docker Volume Cache Keys
       id: cache_key


### PR DESCRIPTION
self-hosted CI runs in other repos are failing since they're not using the right path for getting docker compose version as seen in https://github.com/getsentry/snuba/actions/runs/12818778331/job/35745427857?pr=6784