### PR TITLE
fix: Use local path for get-compose-action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ runs:
         fi
 
     - name: Get Compose
-      uses: getsentry/self-hosted/get-compose-action@master
+      uses: ${{ github.action_path }}get-compose-action
 
     - name: Compute Docker Volume Cache Keys
       id: cache_key


### PR DESCRIPTION
Follow up to #3539
