### PR TITLE
ci: Remove obsolete `dcr up -w` from import test

### DIFF
--- a/_integration-test/test_02_backup.py
+++ b/_integration-test/test_02_backup.py
@@ -66,11 +66,6 @@ def test_02_import(setup_backup_restore_env_variables):
             capture_output=True,
         )
 
-    subprocess.run(
-        ["docker", "compose", "--ansi", "never", "up", "--wait"],
-        check=True,
-        capture_output=True,
-    )
     sentry_admin_sh = os.path.join(os.getcwd(), "sentry-admin.sh")
     subprocess.run(
         [

--- a/sentry-admin.sh
+++ b/sentry-admin.sh
@@ -23,6 +23,7 @@ on the host filesystem. Commands that write files should write them to the '/sen
 # Actual invocation that runs the command in the container.
 invocation() {
   $dc up postgres --wait
+  $dc up redis --wait
   $dcr --no-deps -v "$VOLUME_MAPPING" -T -e SENTRY_LOG_LEVEL=CRITICAL web "$@" 2>&1
 }
 


### PR DESCRIPTION
I _think_ we can get away with this but let's see what the CI thinks. If it passes, it should save us another minuter or two.

Another record: 8m 49s

![image](https://github.com/user-attachments/assets/555024f6-26c2-48ba-a759-7c9dd151d067)
