### PR TITLE
feat: merge `.env` and `.env.custom` file during installation

### DIFF
--- a/_unit-test/merge-env-file-test.sh
+++ b/_unit-test/merge-env-file-test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# This is a test file for a part of `_lib.sh`, where we read `.env.custom` file if there is one.
+# We only want to give very minimal value to the `.env.custom` file, and expect that it would
+# be merged with the original `.env` file, with the `.env.custom` file taking precedence.
+cat <<EOF > .env.custom
+SENTRY_EVENT_RETENTION_DAYS=10
+EOF
+
+# The `_test_setup.sh` script sources `install/_lib.sh`, so.. finger crossed this should works.
+source _unit-test/_test_setup.sh
+
+test "$SENTRY_EVENT_RETENTION_DAYS" == "10"
+echo "Pass"
+test "$SENTRY_BIND" == "9000"
+echo "Pass"
+test "$COMPOSE_PROJECT_NAME" == "sentry-self-hosted"
+echo "Pass"
+
+rm .env.custom
+
+report_success

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -17,7 +17,12 @@ else
 fi
 
 # Read .env for default values with a tip o' the hat to https://stackoverflow.com/a/59831605/90297
-t=$(mktemp) && export -p >"$t" && set -a && . $_ENV && set +a && . "$t" && rm "$t" && unset t
+t=$(mktemp) && export -p >"$t" && set -a && . ".env" && set +a && . "$t" && rm "$t" && unset t
+
+if [[ -f .env.custom ]]; then
+  # Read .env.custom file to override the defaults environment variables
+  local q=$(mktemp) && export -p >"$q" && set -a && . ".env.custom" && set +a && . "$q" && rm "$q" && unset q
+fi
 
 if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
   _group="::group::"


### PR DESCRIPTION
Closes https://github.com/getsentry/self-hosted/issues/3558

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
