### PR TITLE
refactor: move system.url-prefix under systems settings section

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -45,6 +45,10 @@ mail.host: 'smtp'
 # System Settings #
 ###################
 
+# The URL prefix in which Sentry is accessible
+# system.url-prefix: https://example.sentry.com
+system.internal-url-prefix: 'http://web:9000'
+
 # If this file ever becomes compromised, it's important to generate a new key.
 # Changing this value will result in all current sessions being invalidated.
 # A new key can be generated with `$ sentry config generate-secret-key`
@@ -79,9 +83,6 @@ releasefile.cache-path: '/data/releasefile-cache'
 #   secret_key: 'XXXXXXX'
 #   bucket_name: 's3-bucket-name'
 
-# The URL prefix in which Sentry is accessible
-# system.url-prefix: https://example.sentry.com
-system.internal-url-prefix: 'http://web:9000'
 symbolicator.enabled: true
 symbolicator.options:
   url: "http://symbolicator:3021"


### PR DESCRIPTION
Not sure why, but `system.url-prefix` and `system.internal-url-prefix` were not under `System Settings` in sentry/config.example.yml

The PR simply moves the three lines to the right section.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
