### PR TITLE
Use docker-compose if version is gte docker compose

### DIFF
--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -26,6 +26,12 @@ if [[ -z "$COMPOSE_VERSION" ]]; then
   exit 1
 fi
 
+STANDALONE_COMPOSE_VERSION=$($dc_base_standalone version --short || echo '')
+if [[ "$(vergte ${COMPOSE_VERSION//v/} ${STANDALONE_COMPOSE_VERSION//v/})" -eq 1 ]]; then
+  COMPOSE_VERSION="${STANDALONE_COMPOSE_VERSION}"
+  dc_base='docker-compose'
+fi
+
 if [[ "$(vergte ${COMPOSE_VERSION//v/} $MIN_COMPOSE_VERSION)" -eq 1 ]]; then
   echo "FAIL: Expected minimum $dc_base version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
   exit 1

--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -10,6 +10,7 @@ echo "${_group}Initializing Docker Compose ..."
 
 # To support users that are symlinking to docker-compose
 dc_base="$(docker compose version &>/dev/null && echo 'docker compose' || echo 'docker-compose')"
+dc_base_standalone="$(docker-compose version &>/dev/null && echo 'docker-compose')"
 if [[ "$(basename $0)" = "install.sh" ]]; then
   dc="$dc_base --ansi never --env-file ${_ENV}"
 else


### PR DESCRIPTION
Fixes #3587 

This PR tries to use docker-compose if its version is greater than docker compose.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
