### PR TITLE
Bump docker-compose 2.33.1

### DIFF
--- a/get-compose-action/action.yaml
+++ b/get-compose-action/action.yaml
@@ -2,7 +2,7 @@ name: "Get Docker Compose"
 inputs:
   version:
     required: false
-    default: 2.32.3
+    default: 2.33.1
     description: "Docker Compose version"
 
 runs:


### PR DESCRIPTION
Fixes https://github.com/getsentry/self-hosted/issues/3596.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
