### PR TITLE
Fix unbound variable error in install script

### DIFF
--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -56,7 +56,6 @@ function ensure_file_from_example {
 # Check the version of $1 is greater than or equal to $2 using sort. Note: versions must be stripped of "v"
 function vergte() {
   printf "%s\n%s" $1 $2 | sort --version-sort --check=quiet --reverse
-  echo $?
 }
 
 SENTRY_CONFIG_PY=sentry/sentry.conf.py

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -8,13 +8,13 @@ if [[ -z "$DOCKER_VERSION" ]]; then
   exit 1
 fi
 
-if [[ "$(vergte ${DOCKER_VERSION//v/} $MIN_DOCKER_VERSION)" -eq 1 ]]; then
+if ! vergte ${DOCKER_VERSION//v/} $MIN_DOCKER_VERSION; then
   echo "FAIL: Expected minimum docker version to be $MIN_DOCKER_VERSION but found $DOCKER_VERSION"
   exit 1
 fi
 echo "Found Docker version $DOCKER_VERSION"
 
-if [[ "$(vergte ${COMPOSE_VERSION//v/} $MIN_COMPOSE_VERSION)" -eq 1 ]]; then
+if ! vergte ${COMPOSE_VERSION//v/} $MIN_COMPOSE_VERSION; then
   echo "FAIL: Expected minimum $dc_base version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
   exit 1
 fi

--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -20,7 +20,7 @@ if [[ -z "$COMPOSE_VERSION" && -z "$STANDALONE_COMPOSE_VERSION" ]]; then
   exit 1
 fi
 
-if [[ -z "$COMPOSE_VERSION" || -n "$STANDALONE_COMPOSE_VERSION" && "$(vergte ${COMPOSE_VERSION//v/} ${STANDALONE_COMPOSE_VERSION//v/})" -eq 1 ]]; then
+if [[ -z "$COMPOSE_VERSION" ]] || [[ -n "$STANDALONE_COMPOSE_VERSION" ]] && ! vergte ${COMPOSE_VERSION//v/} ${STANDALONE_COMPOSE_VERSION//v/}; then
   COMPOSE_VERSION="${STANDALONE_COMPOSE_VERSION}"
   dc_base="$dc_base_standalone"
 fi


### PR DESCRIPTION
If the docker-compose version was less than the minimum required version, the install script would error out like this:

```
❯ ./install.sh
<snip>
▶ Checking minimum requirements ...
Found Docker version 27.5.1
install/check-minimum-requirements.sh: line 17: install: unbound variable
```

With this patch, the script correctly identifies the out-of-date docker-compose version and bails out with a more helpful message:
```
❯ ./install.sh
<snip>
▶ Checking minimum requirements ...
Found Docker version 27.5.1
FAIL: Expected minimum docker compose version to be 2.132.2 but found 2.32.4-desktop.1
```

(Note that `2.132.2` is not a real docker-compose version; I've edited the `install/_min-requirements.sh` file locally for testing, to make the installed version out of date.)

Also tested that the success case still works (by removing the aforementioned local edit):
```
❯ ./install.sh
<snip>
▶ Checking minimum requirements ...
Found Docker version 27.5.1
Found Docker Compose version 2.32.4-desktop.1
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
