### PR TITLE
ref: Less complicated docker compose detection

### DIFF
--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -9,22 +9,20 @@ fi
 echo "${_group}Initializing Docker Compose ..."
 
 # To support users that are symlinking to docker-compose
-dc_base="$(docker compose version &>/dev/null && echo 'docker compose' || echo 'docker-compose')"
+dc_base="$(docker compose version &>/dev/null && echo 'docker compose' || echo '')"
 dc_base_standalone="$(docker-compose version &>/dev/null && echo 'docker-compose' || echo '')"
 
-COMPOSE_VERSION=$($dc_base version --short || echo '')
-STANDALONE_COMPOSE_VERSION=$($dc_base_standalone version --short &>/dev/null || echo '')
+COMPOSE_VERSION=$([ -z "$dc_base" ] && $dc_base version --short || echo '')
+STANDALONE_COMPOSE_VERSION=$([ -z "$dc_base_standalone" ] && $dc_base_standalone version --short &>/dev/null || echo '')
 
 if [[ -z "$COMPOSE_VERSION" && -z "$STANDALONE_COMPOSE_VERSION" ]]; then
   echo "FAIL: Docker Compose is required to run self-hosted"
   exit 1
 fi
 
-if [[ ! -z "${STANDALONE_COMPOSE_VERSION}" ]]; then
-  if [[ "$(vergte ${COMPOSE_VERSION//v/} ${STANDALONE_COMPOSE_VERSION//v/})" -eq 1 ]]; then
-    COMPOSE_VERSION="${STANDALONE_COMPOSE_VERSION}"
-    dc_base="$dc_base_standalone"
-  fi
+if [[ -z "$COMPOSE_VERSION" || ! -z "$STANDALONE_COMPOSE_VERSION" && "$(vergte ${COMPOSE_VERSION//v/} ${STANDALONE_COMPOSE_VERSION//v/})" -eq 1 ]]; then
+  COMPOSE_VERSION="${STANDALONE_COMPOSE_VERSION}"
+  dc_base="$dc_base_standalone"
 fi
 
 if [[ "$(basename $0)" = "install.sh" ]]; then

--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -12,15 +12,15 @@ echo "${_group}Initializing Docker Compose ..."
 dc_base="$(docker compose version &>/dev/null && echo 'docker compose' || echo '')"
 dc_base_standalone="$(docker-compose version &>/dev/null && echo 'docker-compose' || echo '')"
 
-COMPOSE_VERSION=$([ -z "$dc_base" ] && $dc_base version --short || echo '')
-STANDALONE_COMPOSE_VERSION=$([ -z "$dc_base_standalone" ] && $dc_base_standalone version --short &>/dev/null || echo '')
+COMPOSE_VERSION=$([ -n "$dc_base" ] && $dc_base version --short || echo '')
+STANDALONE_COMPOSE_VERSION=$([ -n "$dc_base_standalone" ] && $dc_base_standalone version --short &>/dev/null || echo '')
 
 if [[ -z "$COMPOSE_VERSION" && -z "$STANDALONE_COMPOSE_VERSION" ]]; then
   echo "FAIL: Docker Compose is required to run self-hosted"
   exit 1
 fi
 
-if [[ -z "$COMPOSE_VERSION" || ! -z "$STANDALONE_COMPOSE_VERSION" && "$(vergte ${COMPOSE_VERSION//v/} ${STANDALONE_COMPOSE_VERSION//v/})" -eq 1 ]]; then
+if [[ -z "$COMPOSE_VERSION" || -n "$STANDALONE_COMPOSE_VERSION" && "$(vergte ${COMPOSE_VERSION//v/} ${STANDALONE_COMPOSE_VERSION//v/})" -eq 1 ]]; then
   COMPOSE_VERSION="${STANDALONE_COMPOSE_VERSION}"
   dc_base="$dc_base_standalone"
 fi

--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -9,7 +9,7 @@ fi
 echo "${_group}Initializing Docker Compose ..."
 
 # To support users that are symlinking to docker-compose
-dc_base="$(docker compose version &>/dev/null && echo 'docker compose' || echo '')"
+dc_base="$(docker compose version --short &>/dev/null && echo 'docker compose' || echo '')"
 dc_base_standalone="$(docker-compose version &>/dev/null && echo 'docker-compose' || echo '')"
 
 COMPOSE_VERSION=$([ -n "$dc_base" ] && $dc_base version --short || echo '')


### PR DESCRIPTION
With #3595, we now check both `docker-compose` and `docker compose` versions so this patch removes the implicit fallback to `docker-compose` for `$dc_base` and makes it explicit.
