### PR TITLE
Add --short to docker-compose version

### DIFF
--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -10,7 +10,7 @@ echo "${_group}Initializing Docker Compose ..."
 
 # To support users that are symlinking to docker-compose
 dc_base="$(docker compose version --short &>/dev/null && echo 'docker compose' || echo '')"
-dc_base_standalone="$(docker-compose version &>/dev/null && echo 'docker-compose' || echo '')"
+dc_base_standalone="$(docker-compose version --short &>/dev/null && echo 'docker-compose' || echo '')"
 
 COMPOSE_VERSION=$([ -n "$dc_base" ] && $dc_base version --short || echo '')
 STANDALONE_COMPOSE_VERSION=$([ -n "$dc_base_standalone" ] && $dc_base_standalone version --short &>/dev/null || echo '')


### PR DESCRIPTION
Thanks to @hubertdeng123 in https://github.com/getsentry/self-hosted/pull/3604#discussion_r1982135356 for pointing this out.

```
$ docker-compose --version
Docker Compose version 2.33.1

$ docker-compose --version --short
2.33.1
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
