### PR TITLE
Enforce license compliance only on getsentry repository

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -1,3 +1,4 @@
+---
 name: Enforce License Compliance
 
 on:
@@ -8,6 +9,7 @@ on:
 
 jobs:
   enforce-license-compliance:
+    if: github.repository_owner == 'getsentry'
     runs-on: ubuntu-latest
     steps:
       - name: 'Enforce License Compliance'

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -1,4 +1,3 @@
----
 name: Enforce License Compliance
 
 on:


### PR DESCRIPTION
It fails every time and it isn't needed.
https://github.com/aminvakil/self-hosted/actions/runs/13685684000


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
