### PR TITLE
docs(config): add example config for Google Auth in sentry/config.example.yml

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -133,3 +133,12 @@ transaction-events.force-disable-internal-project: true
 # discord.public-key: "<public key>"
 # discord.client-secret: "<client secret>"
 # discord.bot-token: "<bot token>"
+
+###############
+# Google Auth #
+###############
+
+# Refer to https://develop.sentry.dev/self-hosted/sso/#google-auth
+
+# auth-google.client-id: "<client id>"
+# auth-google.client-secret: "<client secret>"


### PR DESCRIPTION
Add example config for Google Auth in sentry/config.example.yml

```
###############
# Google Auth #
###############

# Refer to https://develop.sentry.dev/self-hosted/sso/#google-auth

# auth-google.client-id: "<client id>"
# auth-google.client-secret: "<client secret>"
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
