### PR TITLE
Minimum requirements for 'errors-only' profile

### DIFF
--- a/install/_min-requirements.sh
+++ b/install/_min-requirements.sh
@@ -5,9 +5,9 @@ MIN_COMPOSE_VERSION='2.32.2'
 # 16 GB minimum host RAM, but there'll be some overhead outside of what
 # can be allotted to docker
 if [[ "$COMPOSE_PROFILES" == "errors-only" ]]; then
-    MIN_RAM_HARD=7000 # MB
-    MIN_CPU_HARD=2
+  MIN_RAM_HARD=7000 # MB
+  MIN_CPU_HARD=2
 else
-    MIN_RAM_HARD=14000 # MB
-    MIN_CPU_HARD=4
+  MIN_RAM_HARD=14000 # MB
+  MIN_CPU_HARD=4
 fi

--- a/install/_min-requirements.sh
+++ b/install/_min-requirements.sh
@@ -4,6 +4,10 @@ MIN_COMPOSE_VERSION='2.32.2'
 
 # 16 GB minimum host RAM, but there'll be some overhead outside of what
 # can be allotted to docker
-MIN_RAM_HARD=14000 # MB
-
-MIN_CPU_HARD=4
+if [[ "$COMPOSE_PROFILES" == "errors-only" ]]; then
+    MIN_RAM_HARD=7000 # MB
+    MIN_CPU_HARD=2
+else
+    MIN_RAM_HARD=14000 # MB
+    MIN_CPU_HARD=4
+fi


### PR DESCRIPTION
Using the [errors-only](https://develop.sentry.dev/self-hosted/experimental/errors-only/) profile, fewer resources are required. About 2 times.