### PR TITLE
chore(relay): specify spool.enveloppe.max_backpressure_memory_percent configuration for handling relay's failing healthcheck

### DIFF
--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -21,6 +21,7 @@ processing:
 #  max_memory_percent: 1.0
 # spool:
 #   envelopes:
+#     path: "/your/path"
 #     max_backpressure_memory_percent: 1.0
 
 # If you have statsd server, you can utilize that to monitor self-hosted Relay.

--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -14,10 +14,14 @@ processing:
 
 # In some cases, relay might fail to find out the actual machine memory
 # therefore it makes the healthcheck fail and events can't be submitted.
+# See https://github.com/getsentry/self-hosted/issues/3330
 # As a workaround, uncomment the following line:
 #
 # health:
 #  max_memory_percent: 1.0
+# spool:
+#   envelopes:
+#     max_backpressure_memory_percent: 1.0
 
 # If you have statsd server, you can utilize that to monitor self-hosted Relay.
 # To start, uncomment the following line and adjust the options as needed.

--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -14,18 +14,18 @@ processing:
 
 # In some cases, relay might fail to find out the actual machine memory
 # therefore it makes the healthcheck fail and events can't be submitted.
-# See https://github.com/getsentry/self-hosted/issues/3330
-# As a workaround, uncomment the following line:
+# See https://github.com/getsentry/self-hosted/issues/3330 for more details.
+# As a workaround, uncomment the following `health` and `spool` sections:
 #
 # health:
 #  max_memory_percent: 1.0
 # spool:
 #   envelopes:
-#     path: "/your/path"
+#     path: "/tmp/relay-spool-envelopes"
 #     max_backpressure_memory_percent: 1.0
 
 # If you have statsd server, you can utilize that to monitor self-hosted Relay.
-# To start, uncomment the following line and adjust the options as needed.
+# To start, uncomment the following `metrics` section and adjust the options as needed.
 #
 # metrics:
 #  statsd: "100.100.123.123:8125" # It is recommended to use IP address instead of domain name


### PR DESCRIPTION
Although a fix is being rolled out, that does not mean every relay instance would suddenly be fixed. We would need to still provide a workaround for people to try out. Refer to this specific issue comment: https://github.com/getsentry/self-hosted/issues/3330#issuecomment-2751092219




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
