### PR TITLE
Use dc variable in clickhouse step

### DIFF
--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -1,7 +1,7 @@
 echo "${_group}Upgrading Clickhouse ..."
 
 # First check to see if user is upgrading by checking for existing clickhouse volume
-if docker compose ps -a | grep -q clickhouse; then
+if $dc ps -a | grep -q clickhouse; then
   # Start clickhouse if it is not already running
   $dc up --wait clickhouse
 


### PR DESCRIPTION
Using `$dc` instead of `docker compose` ensures users which still rely on `docker-compose` can execute `upgrade-clickhouse.sh`.

Thanks to @csvan for bringing this up in https://github.com/getsentry/self-hosted/issues/3630#issuecomment-2745377412.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
