### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/_integration-test/test_01_basics.py
+++ b/_integration-test/test_01_basics.py
@@ -177,8 +177,8 @@ def test_custom_certificate_authorities():
         .issuer_name(ca_name)
         .public_key(ca_key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.utcnow())
-        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1))
         .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
         .add_extension(
             x509.KeyUsage(


### PR DESCRIPTION
# PR Summary
This small PR fixes the `datetime` deprecation warnings which you can find in the CI logs:
```python
 /home/runner/work/_actions/getsentry/self-hosted/master/_integration-test/test_01_basics.py:303: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```