### PR TITLE
Add missing lib script to sentry-admin.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-set -eE
+set -eEuo pipefail
+test "${DEBUG:-}" && set -x
+
+# Override any user-supplied umask that could cause problems, see #1222
+umask 002
 
 # Pre-pre-flight? 🤷
 if [[ -n "$MSYSTEM" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ test "${DEBUG:-}" && set -x
 umask 002
 
 # Pre-pre-flight? 🤷
-if [[ -n "$MSYSTEM" ]]; then
+if [[ -n "${MSYSTEM:-}" ]]; then
   echo "Seems like you are using an MSYS2-based system (such as Git Bash) which is not supported. Please use WSL instead."
   exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ if [[ -n "$MSYSTEM" ]]; then
   exit 1
 fi
 
+source install/_logging.sh
 source install/_lib.sh
 
 # Pre-flight. No impact yet.

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -4,10 +4,6 @@ test "${DEBUG:-}" && set -x
 # Override any user-supplied umask that could cause problems, see #1222
 umask 002
 
-# Thanks to https://unix.stackexchange.com/a/145654/108960
-log_file=sentry_install_log-$(date +'%Y-%m-%d_%H-%M-%S').txt
-exec &> >(tee -a "$log_file")
-
 # Allow `.env` overrides using the `.env.custom` file.
 # We pass this to docker compose in a couple places.
 if [[ -f .env.custom ]]; then

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -1,9 +1,3 @@
-set -euo pipefail
-test "${DEBUG:-}" && set -x
-
-# Override any user-supplied umask that could cause problems, see #1222
-umask 002
-
 # Allow `.env` overrides using the `.env.custom` file.
 # We pass this to docker compose in a couple places.
 if [[ -f .env.custom ]]; then

--- a/install/_logging.sh
+++ b/install/_logging.sh
@@ -1,0 +1,3 @@
+# Thanks to https://unix.stackexchange.com/a/145654/108960
+log_file=sentry_install_log-$(date +'%Y-%m-%d_%H-%M-%S').txt
+exec &> >(tee -a "$log_file")

--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -34,5 +34,5 @@ proxy_args="--build-arg http_proxy=${http_proxy:-} --build-arg https_proxy=${htt
 dcr="$dc run --pull=never --rm"
 dcb="$dc build $proxy_args"
 dbuild="docker build $proxy_args"
-
+echo "$dcr"
 echo "${_endgroup}"

--- a/sentry-admin.sh
+++ b/sentry-admin.sh
@@ -4,6 +4,7 @@
 cd $(dirname $0)
 
 # Detect docker and platform state.
+source install/_lib.sh
 source install/dc-detect-version.sh
 source install/detect-platform.sh
 


### PR DESCRIPTION
Sentry Admin Script always fail because of missing import of lib script.

Fixes #3700.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
