### PR TITLE
add shellcheck action to lint bash scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,40 @@
+---
+name: "ShellCheck"
+on:
+  push:
+    paths:
+      - "**.sh"
+    branches: [master]
+  pull_request:
+    paths:
+      - "**.sh"
+    branches: [master]
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run ShellCheck
+        run: |
+          git diff --name-only -z `git merge-base origin/master HEAD` -- \
+            'install/_lib.sh' \
+          | xargs -0 -r -- \
+            shellcheck \
+              --shell=bash \
+              --exclude=SC1090,SC1091 \
+              --format=json1 \
+          | jq -r '
+            .comments
+            | map(.level |= if ([.] | inside(["info", "style"])) then "notice" else . end)
+            | .[] as $note
+            | "::\($note.level) file=\($note.file),line=\($note.line),endLine=\($note.endLine),col=\($note.column),endColumn=\($note.endColumn)::[SC\($note.code)] \($note.message)"
+          ' \
+          | grep . >&2 && exit 1
+
+          exit 0

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -33,6 +33,7 @@ function ensure_file_from_example {
     echo "$target already exists, skipped creation."
   else
     # sed from https://stackoverflow.com/a/25123013/90297
+    # shellcheck disable=SC2001
     example="$(echo "$target" | sed 's/\.[^.]*$/.example&/')"
     if [[ ! -f "$example" ]]; then
       echo "Oops! Where did $example go? 🤨 We need it in order to create $target."
@@ -45,14 +46,14 @@ function ensure_file_from_example {
 
 # Check the version of $1 is greater than or equal to $2 using sort. Note: versions must be stripped of "v"
 function vergte() {
-  printf "%s\n%s" $1 $2 | sort --version-sort --check=quiet --reverse
+  printf "%s\n%s" "$1" "$2" | sort --version-sort --check=quiet --reverse
 }
 
-SENTRY_CONFIG_PY=sentry/sentry.conf.py
-SENTRY_CONFIG_YML=sentry/config.yml
+export SENTRY_CONFIG_PY=sentry/sentry.conf.py
+export SENTRY_CONFIG_YML=sentry/config.yml
 
 # Increase the default 10 second SIGTERM timeout
 # to ensure celery queues are properly drained
 # between upgrades as task signatures may change across
 # versions
-STOP_TIMEOUT=60 # seconds
+export STOP_TIMEOUT=60 # seconds


### PR DESCRIPTION

Hello.
I would like to add [shellcheck](https://www.shellcheck.net/) linter for install scripts.

To avoid messing with https://github.com/getsentry/self-hosted/pull/3673 podman PR (and to not edit all scripts at once) this action only checks `install/_lib.sh`

I'm willing to slowly add all other `*.sh` scripts too.

Some trade-offs I made:
1. checks restricted to `install/_lib.sh` but action runs on any `**.sh` change.
1. [SC1090](https://www.shellcheck.net/wiki/SC1090) and [SC1091](https://www.shellcheck.net/wiki/SC1091) disabled because I don't have full context on how env-sources are used
1. `ensure_file_from_example()` excluded as kinda false-positive, pure bash solution won't be more readable I suppose
1. direct shellcheck run is used because tool is preinstalled and it's output could easily be converted to action annotations

Warnings from unmodified lib.sh are available in [this PR](https://github.com/doc-sheet/self-hosted/pull/2/files#diff-1b8181453221651d519090bfd43b23252b324c5fc3756c6f61de3c6aeed9a5c1)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
