### PR TITLE
chore: prune removed feature flags on main repository

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -294,20 +294,11 @@ SENTRY_FEATURES.update(
         )
         # Starfish related flags
         + (
-            "organizations:deprecate-fid-from-performance-score",
             "organizations:indexed-spans-extraction",
             "organizations:insights-entry-points",
             "organizations:insights-initial-modules",
             "organizations:insights-addon-modules",
-            "organizations:mobile-ttid-ttfd-contribution",
-            "organizations:performance-calculate-score-relay",
             "organizations:standalone-span-ingestion",
-            "organizations:starfish-browser-resource-module-image-view",
-            "organizations:starfish-browser-resource-module-ui",
-            "organizations:starfish-browser-webvitals",
-            "organizations:starfish-browser-webvitals-pageoverview-v2",
-            "organizations:starfish-browser-webvitals-replace-fid-with-inp",
-            "organizations:starfish-browser-webvitals-use-backend-scores",
             "organizations:starfish-mobile-appstart",
             "projects:span-metrics-extraction",
             "projects:span-metrics-extraction-addons",


### PR DESCRIPTION
Some feature flags regarding starfish and performance has been removed from the codebase. We should tidy up the ones defined on self-hosted to avoid confusion.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
