### PR TITLE
feat: Add taskbroker + worker + scheduler

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,7 @@ SENTRY_IMAGE=getsentry/sentry:nightly
 SNUBA_IMAGE=getsentry/snuba:nightly
 RELAY_IMAGE=getsentry/relay:nightly
 SYMBOLICATOR_IMAGE=getsentry/symbolicator:nightly
+TASKBROKER_IMAGE=getsentry/taskbroker:nightly
 VROOM_IMAGE=getsentry/vroom:nightly
 HEALTHCHECK_INTERVAL=30s
 HEALTHCHECK_TIMEOUT=1m30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -482,6 +482,26 @@ services:
         <<: *depends_on-healthy
       web:
         <<: *depends_on-healthy
+  taskbroker:
+    <<: *restart_policy
+    image: "$TASKBROKER_IMAGE"
+    environment:
+      TASKBROKER_KAFKA_CLUSTER: "kafka:9092"
+      TASKBROKER_KAFKA_DEADLETTER_CLUSTER: "kafka:9092"
+      TASKBROKER_DB_PATH: "/opt/sqlite/taskbroker-activations.sqlite"
+    ports:
+      - "$SENTRY_BIND:50051/tcp"
+    volumes:
+      - sentry-taskbroker:/opt/sqlite
+    depends_on:
+      kafka:
+        <<: *depends_on-healthy
+  taskscheduler:
+    <<: *sentry_defaults
+    command: run taskworker-scheduler
+  taskworker:
+    <<: *sentry_defaults
+    command: run taskworker --concurrency=4 --rpc-host=taskbroker:50051 --num-brokers=1
   vroom:
     <<: *restart_policy
     image: "$VROOM_IMAGE"
@@ -536,6 +556,10 @@ volumes:
   # Not being external will still persist data across restarts.
   # It won't persist if someone does a docker compose down -v.
   sentry-vroom:
+  # This volume stores task data that is inflight
+  # It should persist across restarts. If this volume is
+  # deleted, up to ~2048 tasks will be lost.
+  sentry-taskbroker:
   # These store ephemeral data that needn't persist across restarts.
   # That said, volumes will be persisted across restarts until they are deleted.
   sentry-secrets:


### PR DESCRIPTION
Add a taskbroker, scheduler and worker pod. While these pods aren't doing much right now, in a subsequent release they will and the cron/worker containers will be removed/replaced by these new containers.

Refs getsentry/taskbroker#267

### TODO
- [ ] Get dockerhub repository created
- [ ] Validate image publishing to dockerhub.