### PR TITLE
tests: Install version 2.x of Python SDK

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-sentry-sdk>=2.4.0
+sentry-sdk>=2.4.0,<3.0.0
 pytest>=8.0.0
 pytest-cov>=4.1.0
 pytest-rerunfailures>=11.0


### PR DESCRIPTION
For some reason we're installing an alpha version of the Python SDK in the integration test. This breaks pytest-sentry (we're working on a fix there). Temporarily restricting Python SDK to current stable major.