### PR TITLE
feat: migrate to arm64-compatible smtp image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,12 +91,12 @@ x-snuba-defaults: &snuba_defaults
 services:
   smtp:
     <<: *restart_policy
-    platform: linux/amd64
-    image: tianon/exim4
-    hostname: "${SENTRY_MAIL_HOST:-}"
+    image: registry.gitlab.com/egos-tech/smtp
     volumes:
       - "sentry-smtp:/var/spool/exim4"
       - "sentry-smtp-log:/var/log/exim4"
+    environment:
+      - MAILNAME=${SENTRY_MAIL_HOST:-}
   memcached:
     <<: *restart_policy
     image: "memcached:1.6.26-alpine"


### PR DESCRIPTION
Migrated from `tianon/exim4` image that does not support `arm64` to `registry.gitlab.com/egos-tech/smtp` that does. Also both use `exim4` under the hood so no changes to the volumes were necessary.

The initial suggestion was to migrate to `ixdotai/smtp`, but it [seems to be deprecated](https://github.com/ix-ai/smtp?tab=readme-ov-file#deprecation-notice).

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
