### PR TITLE
enable shell linter for more scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,12 +23,16 @@ jobs:
       - name: Run ShellCheck
         run: |
           git diff --name-only -z `git merge-base origin/master HEAD` -- \
-            'install/_lib.sh' \
+            install/_lib.sh \
+            'optional-modifications/**.sh' \
+            'scripts/**.sh' \
+            unit-test.sh \
+            'workstation/**.sh' \
           | xargs -0 -r -- \
             shellcheck \
               --shell=bash \
-              --exclude=SC1090,SC1091 \
               --format=json1 \
+              --external-sources \
           | jq -r '
             .comments
             | map(.level |= if ([.] | inside(["info", "style"])) then "notice" else . end)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -7,4 +7,5 @@ NEW_VERSION="$2"
 sed -i -e "s/^\(SENTRY\|SNUBA\|RELAY\|SYMBOLICATOR\|TASKBROKER\|VROOM\)_IMAGE=\([^:]\+\):.\+\$/\1_IMAGE=\2:$NEW_VERSION/" .env
 sed -i -e "s/^\# Self-Hosted Sentry .*/# Self-Hosted Sentry $NEW_VERSION/" README.md
 
+[ -z "$OLD_VERSION" ] || echo "Previous version: $OLD_VERSION"
 echo "New version: $NEW_VERSION"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 cmd="restore $1"
 source scripts/_lib.sh
+
 $cmd

--- a/unit-test.sh
+++ b/unit-test.sh
@@ -5,7 +5,7 @@ export REPORT_SELF_HOSTED_ISSUES=0 # will be over-ridden in the relevant test
 FORCE_CLEAN=1 "./scripts/reset.sh"
 fail=0
 for test_file in _unit-test/*-test.sh; do
-  if [ "$1" -a "$1" != "$test_file" ]; then
+  if [ -n "$1" ] && [ "$1" != "$test_file" ]; then
     echo "🙊 Skipping $test_file ..."
     continue
   fi

--- a/workstation/200_download-self-hosted.sh
+++ b/workstation/200_download-self-hosted.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+set -eo pipefail
 
 # Create getsentry folder and enter.
 mkdir /home/user/getsentry


### PR DESCRIPTION
Hello!

Another batch of shellcheck fixes, warnings can be seen [here](https://github.com/doc-sheet/self-hosted/pull/3/files#diff-db1fee65b65ba2eaf52a4f3f66a6ad40230ff85501acc04885eadf7b1a3642c7)

I did my best to find out is anyone was working with changed files.

Ignores of [SC1090](https://www.shellcheck.net/wiki/SC1090), [SC1091](https://www.shellcheck.net/wiki/SC1091) replaced with `--external-sources` flag.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
