### PR TITLE
fix ownership

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -514,8 +514,6 @@ services:
   vroom:
     <<: *restart_policy
     image: "$VROOM_IMAGE"
-    depends_on:
-      - vroom-init
     environment:
       SENTRY_KAFKA_BROKERS_PROFILING: "kafka:9092"
       SENTRY_KAFKA_BROKERS_OCCURRENCES: "kafka:9092"
@@ -526,6 +524,8 @@ services:
     depends_on:
       kafka:
         <<: *depends_on-healthy
+      vroom-init:
+        <<: *depends_on-default
     profiles:
       - feature-complete
   vroom-cleanup:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -505,9 +505,17 @@ services:
   taskworker:
     <<: *sentry_defaults
     command: run taskworker --concurrency=4 --rpc-host=taskbroker:50051 --num-brokers=1
+  vroom-init:
+    image: busybox
+    command: chown -R 1000:1000 /var/lib/sentry-profiles
+    volumes:
+      - sentry-vroom:/var/lib/sentry-profiles
+    restart: "no"
   vroom:
     <<: *restart_policy
     image: "$VROOM_IMAGE"
+    depends_on:
+      - vroom-init
     environment:
       SENTRY_KAFKA_BROKERS_PROFILING: "kafka:9092"
       SENTRY_KAFKA_BROKERS_OCCURRENCES: "kafka:9092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,6 +525,7 @@ services:
       kafka:
         <<: *depends_on-healthy
       vroom-init:
+        condition: service_completed_successfully
     profiles:
       - feature-complete
   vroom-cleanup:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,7 +525,6 @@ services:
       kafka:
         <<: *depends_on-healthy
       vroom-init:
-        <<: *depends_on-default
     profiles:
       - feature-complete
   vroom-cleanup:


### PR DESCRIPTION
After https://github.com/getsentry/vroom/pull/593, `vroom` container runs as non-privileged user `vroom` with static uid=1000. This broke some integration tests as vroom uses profiles storage as local files in `/var/lib/sentry-profiles` in self-hosted installations.