### PR TITLE
fix(vroom): Explicitly set PROFILES_DIR for upcoming change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -511,7 +511,7 @@ services:
     environment:
       SENTRY_KAFKA_BROKERS_PROFILING: "kafka:9092"
       SENTRY_KAFKA_BROKERS_OCCURRENCES: "kafka:9092"
-      SENTRY_BUCKET_PROFILES: file://localhost//var/lib/sentry-profiles
+      PROFILES_DIR: "/var/lib/sentry-profiles"
       SENTRY_SNUBA_HOST: "http://snuba-api:1218"
     volumes:
       - sentry-vroom:/var/lib/sentry-profiles
@@ -529,6 +529,10 @@ services:
         BASE_IMAGE: "$VROOM_IMAGE"
     entrypoint: "/entrypoint.sh"
     environment:
+      SENTRY_KAFKA_BROKERS_PROFILING: "kafka:9092"
+      SENTRY_KAFKA_BROKERS_OCCURRENCES: "kafka:9092"
+      PROFILES_DIR: "/var/lib/sentry-profiles"
+      SENTRY_SNUBA_HOST: "http://snuba-api:1218"
       # Leaving the value empty to just pass whatever is set
       # on the host system (or in the .env file)
       SENTRY_EVENT_RETENTION_DAYS:


### PR DESCRIPTION
PROFILES_DIR was defaulting to `/var/lib/sentry-profiles` which requires root access. When Vroom image decided to go with non-root default user, this started causing permission issues. Now the image is being refactored and it will not use `/var/lib/sentry-profiles` as the default path so we need to explicitly pass it.
