### PR TITLE
fix(taskworker) Remove num-brokers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -500,7 +500,7 @@ services:
     command: run taskworker-scheduler
   taskworker:
     <<: *sentry_defaults
-    command: run taskworker --concurrency=4 --rpc-host=taskbroker:50051 --num-brokers=1
+    command: run taskworker --concurrency=4 --rpc-host=taskbroker:50051
   vroom:
     <<: *restart_policy
     image: "$VROOM_IMAGE"


### PR DESCRIPTION
The num-brokers option generates broker host names that don't exist in self-hosted.
