### PR TITLE
fix: Increase timeout for flakey test

### DIFF
--- a/_integration-test/test_01_basics.py
+++ b/_integration-test/test_01_basics.py
@@ -22,7 +22,7 @@ SENTRY_CONFIG_PY = "sentry/sentry.conf.py"
 SENTRY_TEST_HOST = os.getenv("SENTRY_TEST_HOST", "http://localhost:9000")
 TEST_USER = "test@example.com"
 TEST_PASS = "test123TEST"
-TIMEOUT_SECONDS = 60
+TIMEOUT_SECONDS = 120
 
 
 def poll_for_response(
@@ -128,8 +128,6 @@ def test_receive_event(client_login):
 
     event_id = sentry_sdk.capture_exception(Exception("a failure"))
     assert event_id is not None
-    time.sleep(1)
-    
     response = poll_for_response(
         f"{SENTRY_TEST_HOST}/api/0/projects/sentry/internal/events/{event_id}/", client
     )

--- a/_integration-test/test_01_basics.py
+++ b/_integration-test/test_01_basics.py
@@ -128,6 +128,8 @@ def test_receive_event(client_login):
 
     event_id = sentry_sdk.capture_exception(Exception("a failure"))
     assert event_id is not None
+    time.sleep(1)
+    
     response = poll_for_response(
         f"{SENTRY_TEST_HOST}/api/0/projects/sentry/internal/events/{event_id}/", client
     )


### PR DESCRIPTION
This test has been incredibly flakey as of late which is impacting the Relay CI, as we run these test there as well.
This now tries to mitigate the flakeyness by increasing the timeout.

If you think there is a better way to approach this please do not hesitate to comment, same for if you think this is not the correct way to tackle the flakeyness.

Note: This test also seems to be flakey in self-hosted, this can be seen by search for the test name in github, since codecov will post a comment with the name of the failed test: https://github.com/search?q=org%3Agetsentry+test_01_basics.py&type=pullrequests