### PR TITLE
feat(uptime): Enable uptime in self-hosted

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,7 @@ RELAY_IMAGE=getsentry/relay:nightly
 SYMBOLICATOR_IMAGE=getsentry/symbolicator:nightly
 TASKBROKER_IMAGE=getsentry/taskbroker:nightly
 VROOM_IMAGE=getsentry/vroom:nightly
+UPTIME_CHECKER_IMAGE=getsentry/uptime-checker:nightly
 HEALTHCHECK_INTERVAL=30s
 HEALTHCHECK_TIMEOUT=1m30s
 HEALTHCHECK_RETRIES=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,6 +305,11 @@ services:
     command: rust-consumer --storage spans --consumer-group snuba-spans-consumers --auto-offset-reset=latest --max-batch-time-ms 1000 --no-strict-offset-reset
     profiles:
       - feature-complete
+  snuba-uptime-results-consumer:
+    <<: *snuba_defaults
+    command: rust-consumer --storage uptime_monitor_checks --consumer-group snuba-uptime-results --auto-offset-reset=latest --max-batch-time-ms 750 --no-strict-offset-reset
+    profiles:
+      - feature-complete
   symbolicator:
     <<: *restart_policy
     image: "$SYMBOLICATOR_IMAGE"
@@ -413,6 +418,11 @@ services:
   monitors-clock-tasks:
     <<: *sentry_defaults
     command: run consumer monitors-clock-tasks --consumer-group monitors-clock-tasks
+    profiles:
+      - feature-complete
+  uptime-results:
+    <<: *sentry_defaults
+    command: run consumer uptime-results --consumer-group uptime-results
     profiles:
       - feature-complete
   post-process-forwarder-transactions:
@@ -531,6 +541,28 @@ services:
     command: '"0 0 * * * find /var/vroom/sentry-profiles -type f -mtime +$SENTRY_EVENT_RETENTION_DAYS -delete"'
     volumes:
       - sentry-vroom:/var/vroom/sentry-profiles
+    profiles:
+      - feature-complete
+  uptime-checker:
+    <<: *restart_policy
+    image: "$UPTIME_CHECKER_IMAGE"
+    command: run
+    environment:
+      UPTIME_CHECKER_RESULTS_KAFKA_CLUSTER: kafka:9092
+      UPTIME_CHECKER_REDIS_HOST: redis://redis:6379
+      # Set to `true` will allow uptime checks against private IP addresses
+      UPTIME_CHECKER_ALLOW_INTERNAL_IPS: "false"
+      # The number of times to retry failed checks before reporting them as failed
+      UPTIME_CHECKER_FAILURE_RETRIES: "1"
+      # DNS name servers to use when making checks in the http checker.
+      # Separated by commas. Leaving this unset will default to the systems dns
+      # resolver.
+      #UPTIME_CHECKER_HTTP_CHECKER_DNS_NAMESERVERS: "8.8.8.8,8.8.4.4"
+    depends_on:
+      kafka:
+        <<: *depends_on-healthy
+      redis:
+        <<: *depends_on-healthy
     profiles:
       - feature-complete
 

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -314,8 +314,23 @@ SENTRY_FEATURES.update(
             "organizations:continuous-profiling",
             "organizations:continuous-profiling-stats",
         )
+        # Uptime related flags
+        + (
+            "organizations:uptime",
+            "organizations:uptime-create-issues",
+            # TODO(epurkhiser): We can remove remove these in 25.8.0 since
+            # we'll have released this issue group type
+            # (https://github.com/getsentry/sentry/pull/94827)
+            "organizations:issue-uptime-domain-failure-visible",
+            "organizations:issue-uptime-domain-failure-ingest",
+            "organizations:issue-uptime-domain-failure-post-process-group",
+        )
     }
 )
+
+# TODO(epurkhiser): In 25.8.0 we can drop this option override as we've made it
+# default in sentry (https://github.com/getsentry/sentry/pull/94822)
+SENTRY_OPTIONS["uptime.snuba_uptime_results.enabled"] = True
 
 #######################
 # MaxMind Integration #


### PR DESCRIPTION
This brings uptime features self hosted sentry installations

This was previously blocked on docker images for the uptime-checker being available.

There is a feature flag and option that need to be enabled for now. But we'll likely remove these in the future.

Fixes https://github.com/getsentry/self-hosted/issues/3304

A few notes

- We may want to expose an official way to disable internal-ip filtering in the uptime-checker. Since self-hosted users may wish to monitor internal services, and it's unclear that we filter those out.
