### PR TITLE
fix: set harakiri Django option to 30s

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -235,7 +235,7 @@ SENTRY_WEB_OPTIONS = {
     # caused by GIL issues or deadlocks.
     # Ensure nginx `proxy_read_timeout` configuration (default: 30)
     # on your `nginx.conf` file to be at least 5 seconds longer than this.
-    # "harakiri": 30,
+    # "harakiri": 25,
     # Some stuff so uwsgi will cycle workers sensibly
     "max-requests": 100000,
     "max-requests-delta": 500,


### PR DESCRIPTION
Closes https://github.com/getsentry/self-hosted/issues/1573

From @guoard and @aminvakil who found the issue of "uWSGI reports full listen queue" was caused mostly by workers taking longer times to finish. For folks with bigger Sentry installation, they might want to increase the `proxy_read_timeout` and `harakiri` values to a longer (acceptable) time.

See the GitHub issue linked above for more details.
