### PR TITLE
feat: Swap `trace-view-v1` feature flag with `visibility-explore-view`

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -298,7 +298,7 @@ SENTRY_FEATURES.update(
             "organizations:dashboards-rh-widget",
             "organizations:metrics-extraction",
             "organizations:transaction-metrics-extraction",
-            "organizations:trace-view-v1",
+            "organizations:visibility-explore-view",
             "organizations:dynamic-sampling",
             "projects:custom-inbound-filters",
             "projects:data-forwarding",


### PR DESCRIPTION
The `trace-view-v1` has been removed here: https://github.com/getsentry/sentry/pull/94474
Since EAP items consumer has been enabled on self-hosted, it makes sense to enable `visibility-explore-view` while currently `performance-trace-explorer` is being phased out on SaaS.

Current SaaS also have `performance-trace-explorer` disabled. This information is gathered from Tony Xiao.
