### PR TITLE
feat: inspect docker compose failure on self-hosted e2e action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,3 @@ jobs:
         uses: './'
         with:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Inspect failure
-        if: failure()
-        run: |
-          docker compose ps
-          docker compose logs

--- a/action.yaml
+++ b/action.yaml
@@ -171,6 +171,7 @@ runs:
 
     - name: Inspect failure
       if: failure()
+      shell: bash
       run: |
         echo "::group::Inspect failure - docker compose ps"
         docker compose ps

--- a/action.yaml
+++ b/action.yaml
@@ -168,3 +168,13 @@ runs:
       with:
         directory: ${{ github.action_path }}
         token: ${{ inputs.CODECOV_TOKEN }}
+
+    - name: Inspect failure
+      if: failure()
+      run: |
+        echo "::group::Inspect failure - docker compose ps"
+        docker compose ps
+        echo "::endgroup::"
+        echo "::group::Inspect failure - docker compose logs"
+        docker compose logs
+        echo "::endgroup::"


### PR DESCRIPTION
It's hard to debug docker compose failure on other repositories since they can't see the `docker compose ps` and `docker compose logs`. One problem occurred here: https://github.com/getsentry/relay/pull/4940

This PR aims to provide both commands if failure happens.