### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Test
 on:
   # Run CI on all pushes to the master and release/** branches, and on all new


### PR DESCRIPTION
> [!NOTE]
> This was me playing around with GH Copilot Security. Feel free to merge if you think this helpful. Otherwise, please just close it.

Potential fix for [https://github.com/getsentry/self-hosted/security/code-scanning/12](https://github.com/getsentry/self-hosted/security/code-scanning/12)

To fix this issue, add a `permissions:` block at the top level of the workflow file, directly under the `name:` line and before the `on:` block. This block should specify the minimal permissions required for the jobs in this workflow. Since the jobs only perform test-related tasks and do not push code or manage issues, setting `contents: read` is the safest and most appropriate minimal permission set. No changes to existing functionality are necessary, as the jobs should not require write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
