### PR TITLE
fix(action): missing project directory path for failure inspection

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -174,6 +174,7 @@ runs:
       shell: bash
       run: |
         echo "::group::Inspect failure - docker compose ps"
+        cd ${{ github.action_path }}
         docker compose ps
         echo "::endgroup::"
         echo "::group::Inspect failure - docker compose logs"


### PR DESCRIPTION
This one is missing. First seen here: https://github.com/getsentry/uptime-checker/actions/runs/16429015462/job/46426515654
