### PR TITLE
docs: clearly state that `system.internal-url-prefix` shouldn't be changed

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -52,7 +52,7 @@ mail.host: 'smtp'
 
 # Most of the time, this should NOT be changed. It's used for communication
 # between containers. `web` is the container's name, and `9000` is the
-# default port exposed by the Sentry image. If you want to change the
+# default port opened by the Sentry backend (this is NOT the public port). If you want to change the
 # publicly exposed domain or port, you should probably change
 # `system.url-prefix` instead.
 system.internal-url-prefix: 'http://web:9000'

--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -52,9 +52,11 @@ mail.host: 'smtp'
 
 # Most of the time, this should NOT be changed. It's used for communication
 # between containers. `web` is the container's name, and `9000` is the
-# default port opened by the Sentry backend (this is NOT the public port). If you want to change the
-# publicly exposed domain or port, you should probably change
-# `system.url-prefix` instead.
+# default port opened by the Sentry backend (this is NOT the public port).
+#
+# If you want to change the publicly exposed domain or port, you should change
+# `system.url-prefix` above instead, along with `SENTRY_BIND` in `.env` file.
+# Also see https://develop.sentry.dev/self-hosted/#productionalizing.
 system.internal-url-prefix: 'http://web:9000'
 
 # If this file ever becomes compromised, it's important to generate a new key.

--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -46,7 +46,7 @@ mail.host: 'smtp'
 ###################
 
 # This is the main URL prefix where Sentry can be accessed.
-# Sentry will use this to create links to its different parts of the user interface.
+# Sentry will use this to create links to its different parts of the web UI.
 # This is most helpful if you are using an external reverse proxy.
 # system.url-prefix: https://example.sentry.com
 

--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -45,8 +45,16 @@ mail.host: 'smtp'
 # System Settings #
 ###################
 
-# The URL prefix in which Sentry is accessible
+# This is the main URL prefix where Sentry can be accessed.
+# Sentry will use this to create links to its different parts of the user interface.
+# This is most helpful if you are using an external reverse proxy.
 # system.url-prefix: https://example.sentry.com
+
+# Most of the time, this should NOT be changed. It's used for communication
+# between containers. `web` is the container's name, and `9000` is the
+# default port exposed by the Sentry image. If you want to change the
+# publicly exposed domain or port, you should probably change
+# `system.url-prefix` instead.
 system.internal-url-prefix: 'http://web:9000'
 
 # If this file ever becomes compromised, it's important to generate a new key.


### PR DESCRIPTION
Happened today on Discord where a user changed internal-url-prefix and broke their instance. I think this should be stated clearer for new users and for non-native English speakers.
