### PR TITLE
fix(scripts): every known flags should be shifted before executing the sentry <foo> command

### DIFF
--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -78,7 +78,6 @@ function restore() {
 }
 
 # Needed variables to source error-handling script
-MINIMIZE_DOWNTIME="${MINIMIZE_DOWNTIME:-}"
 export STOP_TIMEOUT=60
 
 # Save logs in order to send envelope to Sentry
@@ -86,16 +85,8 @@ log_file="sentry_${cmd%% *}_log-$(date +%Y-%m-%d_%H-%M-%S).txt"
 exec &> >(tee -a "$log_file")
 version=""
 
-while (($#)); do
-  case "$1" in
-  --report-self-hosted-issues) export REPORT_SELF_HOSTED_ISSUES=1 ;;
-  --no-report-self-hosted-issues) export REPORT_SELF_HOSTED_ISSUES=0 ;;
-  *) version=$1 ;;
-  esac
-  shift
-done
-
 # Source files needed to set up error-handling
+source install/_lib.sh
 source install/dc-detect-version.sh
 source install/detect-platform.sh
 source install/error-handling.sh

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+MINIMIZE_DOWNTIME="${MINIMIZE_DOWNTIME:-}"
+REPORT_SELF_HOSTED_ISSUES="${REPORT_SELF_HOSTED_ISSUES:-}"
+
+while (($#)); do
+  case "$1" in
+  --report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=1 ;;
+  --no-report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=0 ;;
+  --minimize-downtime) MINIMIZE_DOWNTIME=1 ;;
+  *) version=$1 ;;
+  esac
+  shift
+done
+
 cmd="backup $1"
 source scripts/_lib.sh
 $cmd

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+MINIMIZE_DOWNTIME="${MINIMIZE_DOWNTIME:-}"
+REPORT_SELF_HOSTED_ISSUES="${REPORT_SELF_HOSTED_ISSUES:-}"
+
+while (($#)); do
+  case "$1" in
+  --report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=1 ;;
+  --no-report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=0 ;;
+  --minimize-downtime) MINIMIZE_DOWNTIME=1 ;;
+  *) version=$1 ;;
+  esac
+  shift
+done
+
 cmd=reset
 source scripts/_lib.sh
 $cmd

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+MINIMIZE_DOWNTIME="${MINIMIZE_DOWNTIME:-}"
+REPORT_SELF_HOSTED_ISSUES="${REPORT_SELF_HOSTED_ISSUES:-}"
+
+while (($#)); do
+  case "$1" in
+  --report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=1 ;;
+  --no-report-self-hosted-issues) REPORT_SELF_HOSTED_ISSUES=0 ;;
+  --minimize-downtime) MINIMIZE_DOWNTIME=1 ;;
+  *) version=$1 ;;
+  esac
+  shift
+done
+
 cmd="restore $1"
 source scripts/_lib.sh
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/self-hosted/issues/3526

Previously, if this was executed:
```bash
./scripts/backup.sh --no-report-self-hosted-issues
```

The final backup command that will be executed is:
```bash
docker compose run -v "${PWD}/sentry:/sentry-data/backup" --rm -T -e SENTRY_LOG_LEVEL=CRITICAL web export --no-report-self-hosted-issues /sentry-data/backup/backup.json
```

Which is invalid. This PR strips all known flags specific to self-hosted before passing it onto Sentry.

One other option is to enable "ignore unknown options" on click (the CLI dependency) on Sentry, but I don't want to go to that route.
