### PR TITLE
feat: Continue using celery in self-hosted for now

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -442,3 +442,9 @@ JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.
 # }
 # SENTRY_METRICS_SAMPLE_RATE = 1.0   # Adjust this to your needs, default is 1.0
 # SENTRY_METRICS_PREFIX = "sentry."  # Adjust this to your needs, default is "sentry."
+
+#########
+# Tasks #
+#########
+# Disable taskworker and continue using celery.
+SENTRY_OPTIONS["taskworker.enabled"] = False


### PR DESCRIPTION
Disable taskworkers for self-hosted until the documentation has been published.  What I'm not clear on is how to define this option for _existing_ self-hosted installs.

Refs getsentry/sentry#96966