### PR TITLE
fix: add schedulers for generic metrics subscriptions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,6 +267,26 @@ services:
     command: subscriptions-scheduler-executor --dataset metrics --entity metrics_sets --entity metrics_counters --auto-offset-reset=latest --no-strict-offset-reset --consumer-group=snuba-metrics-subscriptions-consumers --followed-consumer-group=snuba-metrics-consumers --schedule-ttl=60 --stale-threshold-seconds=900
     profiles:
       - feature-complete
+  snuba-subscription-consumer-generic-metrics-distributions:
+    <<: *snuba_defaults
+    command: subscriptions-scheduler-executor --dataset generic_metrics --entity=generic_metrics_distributions   --auto-offset-reset=latest --no-strict-offset-reset --consumer-group=snuba-generic-metrics-distributions-subscriptions-schedulers --followed-consumer-group=snuba-gen-metrics-distributions-consumers --schedule-ttl=60 --stale-threshold-seconds=900
+    profiles:
+      - feature-complete
+  snuba-subscription-consumer-generic-metrics-sets:
+    <<: *snuba_defaults
+    command: subscriptions-scheduler-executor --dataset generic_metrics --entity=generic_metrics_sets --auto-offset-reset=latest --no-strict-offset-reset --consumer-group=snuba-generic-metrics-sets-subscriptions-schedulers --followed-consumer-group=snuba-gen-metrics-sets-consumers --schedule-ttl=60 --stale-threshold-seconds=900
+    profiles:
+      - feature-complete
+  snuba-subscription-consumer-generic-metrics-counters:
+    <<: *snuba_defaults
+    command: subscriptions-scheduler-executor --dataset generic_metrics --entity=generic_metrics_counters --auto-offset-reset=latest --no-strict-offset-reset --consumer-group=snuba-generic-metrics-counters-subscriptions-schedulers --followed-consumer-group=snuba-gen-metrics-counters-consumers --schedule-ttl=60 --stale-threshold-seconds=900
+    profiles:
+      - feature-complete
+  snuba-subscription-consumer-generic-metrics-gauges:
+    <<: *snuba_defaults
+    command: subscriptions-scheduler-executor --dataset generic_metrics --entity=generic_metrics_gauges --auto-offset-reset=latest --no-strict-offset-reset --consumer-group=snuba-generic-metrics-gauges-subscriptions-schedulers --followed-consumer-group=snuba-gen-metrics-gauges-consumers --schedule-ttl=60 --stale-threshold-seconds=900
+    profiles:
+      - feature-complete
   snuba-generic-metrics-distributions-consumer:
     <<: *snuba_defaults
     command: rust-consumer --storage generic_metrics_distributions_raw --consumer-group snuba-gen-metrics-distributions-consumers --auto-offset-reset=latest --max-batch-time-ms 750 --no-strict-offset-reset


### PR DESCRIPTION
Fix for https://github.com/getsentry/self-hosted/issues/3838. By analyzing the setup in Snuba [devserver](https://github.com/getsentry/snuba/blob/master/snuba/cli/devserver.py), I've confirmed that in the current setup, self-hosted never acts on a generic metric subscription. I cannot be certain if this is a complete solution to the problem, but I do know it fixed the metric alerts for me. 

Proof:

<img width="1146" height="610" alt="image" src="https://github.com/user-attachments/assets/c66434ef-356a-4109-821d-b8ea68b96b75" />


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
