### PR TITLE
fix(enhancement): ensure correct ownership check before setting permissions of profiles

### DIFF
--- a/install/ensure-correct-permissions-profiles-dir.sh
+++ b/install/ensure-correct-permissions-profiles-dir.sh
@@ -4,6 +4,11 @@
 
 echo "${_group}Ensuring correct permissions on profiles directory ..."
 
-$dcr --no-deps --entrypoint /bin/bash --user root vroom -c 'chown -R vroom:vroom /var/vroom/sentry-profiles && chmod -R o+rwx /var/vroom/sentry-profiles'
+# Check if the parent directory of /var/vroom/sentry-profiles is already owned by vroom:vroom
+if [ "$(stat -c '%U:%G' /var/vroom)" = "vroom:vroom" ]; then
+  echo "Ownership of /var/vroom is already set to vroom:vroom. Skipping chown."
+else
+  $dcr --no-deps --entrypoint /bin/bash --user root vroom -c 'chown -R vroom:vroom /var/vroom/sentry-profiles && chmod -R o+rwx /var/vroom/sentry-profiles'
+fi
 
 echo "${_endgroup}"


### PR DESCRIPTION
Fixes #3841 




<!-- Describe your PR here. -->
Check if the parent directory of /var/vroom/sentry-profiles is already owned by vroom:vroom.
- If it is, do nothing.
- If owner is incorrect, correct it


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
