### PR TITLE
fix(scripts): use `env` to find `bash` interpreter

### DIFF
--- a/install/ensure-correct-permissions-profiles-dir.sh
+++ b/install/ensure-correct-permissions-profiles-dir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # TODO: Remove this after the next hard-stop
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 OLD_VERSION="$1"

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 # Bring master back to nightlies after merge from release branch

--- a/sentry-admin.sh
+++ b/sentry-admin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set the script directory as working directory.
 cd $(dirname $0)


### PR DESCRIPTION
Updates the shebang to use `#!/usr/bin/env bash` for improved portability. This ensures that the script uses the `bash` interpreter found in the user's environment, rather than relying on a hardcoded path.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
