### PR TITLE
Set minimum bash version to 4.4.0

### DIFF
--- a/install/_min-requirements.sh
+++ b/install/_min-requirements.sh
@@ -5,6 +5,8 @@ MIN_COMPOSE_VERSION='2.32.2'
 MIN_PODMAN_VERSION='4.9.3'
 MIN_PODMAN_COMPOSE_VERSION='1.3.0'
 
+MIN_BASH_VERSION='4.4.0'
+
 # 16 GB minimum host RAM, but there'll be some overhead outside of what
 # can be allotted to docker
 if [[ "$COMPOSE_PROFILES" == "errors-only" ]]; then

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -54,4 +54,9 @@ if [[ ! "$SKIP_SSE42_REQUIREMENTS" -eq 1 && "$IS_KVM" -eq 0 && "$DOCKER_ARCH" = 
   fi
 fi
 
+if ! vergte "${BASH_VERSION}" "${MIN_BASH_VERSION}"; then
+  echo "FAIL: Expected minimum bash version to be ${MIN_BASH_VERSION} but found ${BASH_VERSION}"
+  exit 1
+fi
+
 echo "${_endgroup}"


### PR DESCRIPTION
Fixes https://github.com/getsentry/self-hosted/issues/3860 by failing sooner :)

There is possibly an easy fix for #3860, but honestly bash 4.2 is pretty ancient, and I think there will be other problems with that aside from #3860 problem.

Here is bash versions on debian distributions:

```
Package: bash on amd64 -- jessie: 4.3-11+deb8u1; jessie-security: 4.3-11+deb8u2; stretch: 4.4-5; buster: 5.0-4; bullseye: 5.1-2+deb11u1; bookworm: 5.2.15-2+b8; bookworm-proposed-updates: 5.2.15-2+b9; trixie: 5.2.37-2+b5; forky: 5.2.37-2+b5; sid: 5.2.37-2+b5; experimental: 5.3~rc2-1
```

Debian 9 stretch has been released 2020 and it uses bash >= 4.4.
RHEL 8 has been released 2018 and it uses bash >= 4.4.
Ubuntu 18 Bionic has been released 2018 and it uses bash >= 4.4.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
