### PR TITLE
fix: setup swapfile only if runner architecture is X64 or X86

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -144,7 +144,7 @@ runs:
 
     - name: Setup swapfile
       shell: bash
-      if: matrix.os == 'ubuntu-24.04'
+      if: runner.arch == 'X64' || runner.arch == 'X86'
       run: |
         sudo fallocate -l 16G /swapfile
         sudo chmod 600 /swapfile


### PR DESCRIPTION
Using matrix.os only works on self-hosted. SH e2e test on other repositories would still fail.

Refer to https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#runner-context
