### PR TITLE
chore(deps): bump clickhouse to 25.3

### DIFF
--- a/clickhouse/default-password.xml
+++ b/clickhouse/default-password.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+  <users>
+    <default>
+      <password></password>
+      <networks>
+        <ip>::/0</ip>
+      </networks>
+    </default>
+  </users>
+</clickhouse>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
     build:
       context: ./clickhouse
       args:
-        BASE_IMAGE: "altinity/clickhouse-server:23.8.11.29.altinitystable"
+        BASE_IMAGE: "altinity/clickhouse-server:25.3.6.10034.altinitystable"
     ulimits:
       nofile:
         soft: 262144
@@ -199,6 +199,10 @@ services:
         read_only: true
         source: ./clickhouse/config.xml
         target: /etc/clickhouse-server/config.d/sentry.xml
+      - type: bind
+        read_only: true
+        source: "./clickhouse/default-password.xml"
+        target: "/etc/clickhouse-server/users.d/default-password.xml:"
     environment:
       # This limits Clickhouse's memory to 30% of the host memory
       # If you have high volume and your search return incomplete results

--- a/install/upgrade-clickhouse.sh
+++ b/install/upgrade-clickhouse.sh
@@ -14,14 +14,46 @@ if $ps_command | grep -q clickhouse; then
   # Start clickhouse if it is not already running
   start_service_and_wait_ready clickhouse
 
-  # In order to get to 23.8, we need to first upgrade go from 21.8 -> 22.8 -> 23.3 -> 23.8
+  # In order to get to 25.3, we need to first upgrade go from 21.8 -> 22.8 -> 23.3 -> 23.8 -> 24.8 -> 25.3
   version=$($dc exec clickhouse clickhouse-client -q 'SELECT version()')
   if [[ "$version" == "21.8.13.1.altinitystable" || "$version" == "21.8.12.29.altinitydev.arm" ]]; then
+    echo "Detected clickhouse version $version"
     $dc down clickhouse
+
+    echo "Upgrading clickhouse to 22.8"
     $dcb $build_arg BASE_IMAGE=altinity/clickhouse-server:22.8.15.25.altinitystable clickhouse
     start_service_and_wait_ready clickhouse
     $dc down clickhouse
+
+    echo "Upgrading clickhouse to 23.3"
     $dcb $build_arg BASE_IMAGE=altinity/clickhouse-server:23.3.19.33.altinitystable clickhouse
+    start_service_and_wait_ready clickhouse
+    $dc down clickhouse
+
+    echo "Upgrading clickhouse to 23.8"
+    $dcb $build_arg BASE_IMAGE=altinity/clickhouse-server:23.8.11.29.altinitystable clickhouse
+    start_service_and_wait_ready clickhouse
+    $dc down clickhouse
+
+    echo "Upgrading clickhouse to 24.8"
+    $dcb $build_arg BASE_IMAGE=altinity/clickhouse-server:24.8.14.10459.altinitystable clickhouse
+    start_service_and_wait_ready clickhouse
+    $dc down clickhouse
+
+    echo "Upgrading clickhouse to 25.3"
+    $dcb $build_arg BASE_IMAGE=altinity/clickhouse-server:25.3.6.10034.altinitystable clickhouse
+    start_service_and_wait_ready clickhouse
+  elif [[ "$version" == "23.8.11.29.altinitystable" ]]; then
+    echo "Detected clickhouse version $version"
+    $dc down clickhouse
+
+    echo "Upgrading clickhouse to 24.8"
+    $dcb $build_arg BASE_IMAGE=altinity/clickhouse-server:24.8.14.10459.altinitystable clickhouse
+    start_service_and_wait_ready clickhouse
+    $dc down clickhouse
+
+    echo "Upgrading clickhouse to 25.3"
+    $dcb $build_arg BASE_IMAGE=altinity/clickhouse-server:25.3.6.10034.altinitystable clickhouse
     start_service_and_wait_ready clickhouse
   else
     echo "Detected clickhouse version $version. Skipping upgrades!"


### PR DESCRIPTION
See https://github.com/getsentry/snuba/pull/7361:

> We are already running `25.3.6.10034` in `s4s` and some `de` clusters

ClickHouse upgrade PR on snuba: https://github.com/getsentry/snuba/pull/7339 