### PR TITLE
chore(deps): bump patches version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       test: echo stats | nc 127.0.0.1 11211
   redis:
     <<: *restart_policy
-    image: "redis:6.2.14-alpine"
+    image: "redis:6.2.19-alpine"
     healthcheck:
       <<: *healthcheck_defaults
       test: redis-cli ping | grep PONG
@@ -133,7 +133,7 @@ services:
   postgres:
     <<: *restart_policy
     # Using the same postgres version as Sentry dev for consistency purposes
-    image: "postgres:14.11"
+    image: "postgres:14.19-bookworm"
     healthcheck:
       <<: *healthcheck_defaults
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided
@@ -146,7 +146,7 @@ services:
       - "sentry-postgres:/var/lib/postgresql/data"
   kafka:
     <<: *restart_policy
-    image: "confluentinc/cp-kafka:7.6.1"
+    image: "confluentinc/cp-kafka:7.6.6"
     environment:
       # https://docs.confluent.io/platform/current/installation/docker/config-reference.html#cp-kakfa-example
       KAFKA_PROCESS_ROLES: "broker,controller"
@@ -638,7 +638,7 @@ services:
     <<: *restart_policy
     ports:
       - "$SENTRY_BIND:80/tcp"
-    image: "nginx:1.25.4-alpine"
+    image: "nginx:1.29.1-alpine"
     volumes:
       - type: bind
         read_only: true


### PR DESCRIPTION
Except nginx, they don't seem to have any breaking change. See https://nginx.org/en/CHANGES

Other than nginx, patches version are available.
