### PR TITLE
Revert "increase postgres max_connections above 100 connections (#2740)"

### DIFF
--- a/.env
+++ b/.env
@@ -24,8 +24,5 @@ HEALTHCHECK_FILE_INTERVAL=60s
 HEALTHCHECK_FILE_TIMEOUT=10s
 HEALTHCHECK_FILE_RETRIES=3
 HEALTHCHECK_FILE_START_PERIOD=600s
-# Caution: Raising max connections of postgres increases CPU and RAM usage
-# see https://github.com/getsentry/self-hosted/pull/2740 for more information
-POSTGRES_MAX_CONNECTIONS=100
 # Set SETUP_JS_SDK_ASSETS to 1 to enable the setup of JS SDK assets
 # SETUP_JS_SDK_ASSETS=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
     command:
-      ["postgres", "-c", "max_connections=${POSTGRES_MAX_CONNECTIONS:-100}"]
+      ["postgres"]
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
     volumes:


### PR DESCRIPTION
This reverts commit 7691addcb631fee42389896cf4eead0794f11a9d.

As discussed in https://github.com/getsentry/self-hosted/pull/3884#issuecomment-3213919610 .


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
