### PR TITLE
Add restart policy to pgbouncer service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,7 @@ services:
     volumes:
       - "sentry-postgres:/var/lib/postgresql/data"
   pgbouncer:
+    <<: *restart_policy
     image: "edoburu/pgbouncer:v1.24.1-p1"
     healthcheck:
       <<: *healthcheck_defaults


### PR DESCRIPTION
Add my missing restart policy to pgbouncer

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
