### PR TITLE
fix: relay anonymous volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -694,6 +694,8 @@ services:
         read_only: true
         source: ./geoip
         target: /geoip
+      - ./work:/work
+      - ./etc:/etc/relay
     depends_on:
       kafka:
         <<: *depends_on-healthy


### PR DESCRIPTION
Some of the volumes used by the relay container are created as anonymous.
I think it would be better to explicitly specify them in the volumes section.

```json
[SERVER] ~ % docker inspect sentry-self-hosted-relay-1 | grep -A 100 Mounts
"Mounts": [
  {
    "Type": "volume",
    "Name": "997570cba7cf00cb86834775b1ba67994727068b861d12cf696b54c509beb69e",
    "Source": "/var/lib/docker/volumes/997570cba7cf00cb86834775b1ba67994727068b861d12cf696b54c509beb69e/_data",
    "Destination": "/etc/relay",
    "Driver": "local",
    "Mode": "",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "bind",
    "Source": "/srv/self-hosted/sentry/geoip",
    "Destination": "/geoip",
    "Mode": "ro",
    "RW": false,
    "Propagation": "rprivate"
  },
  {
    "Type": "volume",
    "Name": "87cacf8b9804a41bc6bc058dc15a1232051fbb0b6a0644dab6414e885e1dc610",
    "Source": "/var/lib/docker/volumes/87cacf8b9804a41bc6bc058dc15a1232051fbb0b6a0644dab6414e885e1dc610/_data",
    "Destination": "/work",
    "Driver": "local",
    "Mode": "",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "bind",
    "Source": "/srv/self-hosted/sentry/relay",
    "Destination": "/work/.relay",
    "Mode": "ro",
    "RW": false,
    "Propagation": "rprivate"
  }
]
```
