### PR TITLE
feat(tasks): Remove taskworker option override and add worker healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -721,7 +721,9 @@ services:
     command: run taskworker-scheduler
   taskworker:
     <<: *sentry_defaults
-    command: run taskworker --concurrency=4 --rpc-host=taskbroker:50051
+    command: run taskworker --concurrency=4 --rpc-host=taskbroker:50051 --health-check-file-path=/tmp/health.txt
+    healthcheck:
+      <<: *file_healthcheck_defaults
   vroom:
     <<: *restart_policy
     image: "$VROOM_IMAGE"

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -456,9 +456,3 @@ JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.
 # }
 # SENTRY_METRICS_SAMPLE_RATE = 1.0   # Adjust this to your needs, default is 1.0
 # SENTRY_METRICS_PREFIX = "sentry."  # Adjust this to your needs, default is "sentry."
-
-#########
-# Tasks #
-#########
-# Disable taskworker and continue using celery.
-SENTRY_OPTIONS["taskworker.enabled"] = False


### PR DESCRIPTION
Along with getsentry/sentry#99374 and this change taskworkers will be enabled by default in self-hosted. I've left the celery workers active to smooth over any tasks that are in-flight during an upgrade.

Add a worker healtcheck as we have one now.

Refs STREAM-450