### PR TITLE
docs: provide information for SENTRY_AIR_GAP flag on Django config file

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -95,6 +95,14 @@ if env("SENTRY_SYSTEM_SECRET_KEY"):
 # See https://develop.sentry.dev/self-hosted/experimental/errors-only/
 SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") != "feature-complete"
 
+# When running in an air gap environment, set this to True to entirely disable
+# external network calls and features that require internet connectivity.
+#
+# Setting the value to False while running in an air gap environment will
+# cause some containers to raise an exception. One known example is fetching
+# AI model prices from various public APIs.
+SENTRY_AIR_GAP = False
+
 #########
 # Redis #
 #########

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -96,10 +96,10 @@ if env("SENTRY_SYSTEM_SECRET_KEY"):
 SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") != "feature-complete"
 
 # When running in an air-gapped environment, set this to True to entirely disable
-# external network calls and features that require internet connectivity.
+# external network calls and features that require Internet connectivity.
 #
 # Setting the value to False while running in an air-gapped environment will
-# cause some containers to raise an exception. One known example is fetching
+# cause some containers to raise exceptions. One known example is fetching
 # AI model prices from various public APIs.
 SENTRY_AIR_GAP = False
 

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -95,10 +95,10 @@ if env("SENTRY_SYSTEM_SECRET_KEY"):
 # See https://develop.sentry.dev/self-hosted/experimental/errors-only/
 SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") != "feature-complete"
 
-# When running in an air gap environment, set this to True to entirely disable
+# When running in an air-gapped environment, set this to True to entirely disable
 # external network calls and features that require internet connectivity.
 #
-# Setting the value to False while running in an air gap environment will
+# Setting the value to False while running in an air-gapped environment will
 # cause some containers to raise an exception. One known example is fetching
 # AI model prices from various public APIs.
 SENTRY_AIR_GAP = False


### PR DESCRIPTION
Corresponding PR: https://github.com/getsentry/sentry/pull/99281