### PR TITLE
chore(tasks): Remove the worker and cron containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -512,20 +512,6 @@ services:
         - "-c"
         # Courtesy of https://unix.stackexchange.com/a/234089/108960
         - 'exec 3<>/dev/tcp/127.0.0.1/9000 && echo -e "GET /_health/ HTTP/1.1\r\nhost: 127.0.0.1\r\n\r\n" >&3 && grep ok -s -m 1 <&3'
-  cron:
-    <<: *sentry_defaults
-    command: run cron
-  worker:
-    <<: *sentry_defaults
-    command: run worker
-    healthcheck:
-      <<: *healthcheck_defaults
-      test:
-        - CMD
-        - sentry
-        - exec
-        - -c
-        - 'from sentry.celery import app; import os; dest="celery@{}".format(os.environ["HOSTNAME"]); print(app.control.ping(destination=[dest], timeout=5)[0][dest]["ok"])'
   events-consumer:
     <<: *sentry_defaults
     command: run consumer ingest-events --consumer-group ingest-consumer --healthcheck-file-path /tmp/health.txt

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -142,25 +142,6 @@ SENTRY_OPTIONS["redis.clusters"] = {
 }
 
 #########
-# Queue #
-#########
-
-# See https://develop.sentry.dev/services/queue/ for more
-# information on configuring your queue broker and workers. Sentry relies
-# on a Python framework called Celery to manage queues.
-
-rabbitmq_host = None
-if rabbitmq_host:
-    BROKER_URL = "amqp://{username}:{password}@{host}/{vhost}".format(
-        username="guest", password="guest", host=rabbitmq_host, vhost="/"
-    )
-else:
-    BROKER_URL = "redis://:{password}@{host}:{port}/{db}".format(
-        **SENTRY_OPTIONS["redis.clusters"]["default"]["hosts"][0]
-    )
-
-
-#########
 # Cache #
 #########
 


### PR DESCRIPTION
These are replaced by the `taskworker` and `taskscheduler` containers

Refs STREAM-433
