### PR TITLE
Remove proxy_next_upstream directives

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -41,8 +41,6 @@ http {
 	proxy_buffer_size          128k;
 	proxy_buffers              4 256k;
 	proxy_busy_buffers_size    256k;
-	proxy_next_upstream error timeout invalid_header http_502 http_503 non_idempotent;
-	proxy_next_upstream_tries 2;
 
 	# Docker default address pools
 	# https://github.com/moby/libnetwork/blob/3797618f9a38372e8107d8c06f6ae199e1133ae8/ipamutils/utils.go#L10-L22


### PR DESCRIPTION
There is only server in each upstream, so `proxy_next_upstream` directives are useless.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
