### PR TITLE
ref: use dedicated `healthcheck` command for symbolicator & remove cron for `symbolicator-cleanup`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -488,7 +488,7 @@ services:
         target: /etc/symbolicator
     healthcheck:
       <<: *healthcheck_defaults
-      test: ["CMD", "/bin/symbolicator", "healthcheck", "-c /etc/symbolicator/config.yml"]
+      test: ["CMD", "/bin/symbolicator", "healthcheck", "-c", "/etc/symbolicator/config.yml"]
   symbolicator-cleanup:
     <<: *restart_policy
     image: "$SYMBOLICATOR_IMAGE"


### PR DESCRIPTION
This PR depends on https://github.com/getsentry/symbolicator/pull/1799

Symbolicator changed to a distroless image: https://github.com/getsentry/symbolicator/pull/1791
Therefore we'll be missing lots of regular Debian distro goodies, including healthcheck and cron.
