### PR TITLE
Bump redis 6.2.20-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
       test: echo stats | nc 127.0.0.1 11211
   redis:
     <<: *restart_policy
-    image: "redis:6.2.19-alpine"
+    image: "redis:6.2.20-alpine"
     healthcheck:
       <<: *healthcheck_defaults
       test: redis-cli ping | grep PONG


### PR DESCRIPTION
https://redis.io/blog/security-advisory-cve-2025-49844/

This may need another release before 25.10.0 .

self-hosted redis is not exposed to outside of docker network though, so whatever security team decides.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
