### PR TITLE
chore(spans): Remove old snuba-spans consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -450,13 +450,6 @@ services:
       <<: *file_healthcheck_defaults
     profiles:
       - feature-complete
-  snuba-spans-consumer:
-    <<: *snuba_defaults
-    command: rust-consumer --storage spans --consumer-group snuba-spans-consumers --auto-offset-reset=latest --max-batch-time-ms 1000 --no-strict-offset-reset --health-check-file /tmp/health.txt
-    healthcheck:
-      <<: *file_healthcheck_defaults
-    profiles:
-      - feature-complete
   snuba-eap-items-consumer:
     <<: *snuba_defaults
     command: rust-consumer --storage eap_items --consumer-group eap_items_group --auto-offset-reset=latest --max-batch-time-ms 1000 --no-strict-offset-reset --use-rust-processor --health-check-file /tmp/health.txt


### PR DESCRIPTION
Relay does not produce to `snuba-spans` anymore, see https://github.com/getsentry/relay/pull/5163.