### PR TITLE
fix: missing `-dir` flag for seaweedfs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,11 +246,13 @@ services:
     entrypoint: "weed"
     command: >-
         server
+        -dir=/data
         -filer=true
         -filer.port=8888
         -filer.port.grpc=18888
         -filer.defaultReplicaPlacement=000
         -master=true
+        -master.mdir=/data/master
         -master.port=9333
         -master.port.grpc=19333
         -metricsPort=9091


### PR DESCRIPTION
Closes https://github.com/getsentry/self-hosted/issues/3990

Data won't be persisted otherwise. Folks needs to re-create the volume.
