### PR TITLE
Wrong option for taskworker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -742,7 +742,7 @@ services:
     command: run taskworker-scheduler
   taskworker:
     <<: *sentry_defaults
-    command: run taskworker --concurrency=4 --rpc-host=taskbroker:50051 --health-check-file-path=/tmp/health.txt
+    command: run taskworker --concurrency=4 --rpc-host=taskbroker:50051
     healthcheck:
       <<: *file_healthcheck_defaults
   vroom:


### PR DESCRIPTION
Taskworker does not have such  option as  --health-check-file-path=/tmp/health.txt The container fails to start with the following error

taskworker-1  | Error: No such option: --health-check-file-path taskworker-1  | Usage: sentry run taskworker [OPTIONS] taskworker-1  | Try 'sentry run taskworker --help' for help.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
