### PR TITLE
fix: Move files to correct `/data` directory if any volume-related data exists in `/tmp` for SeaweedFS

### DIFF
--- a/install/turn-things-off.sh
+++ b/install/turn-things-off.sh
@@ -1,7 +1,7 @@
 echo "${_group}Turning things off ..."
 
 # Only execute this when `seaweedfs` container is running
-if ! $dc ps --quiet seaweedfs; then
+if [ -z "$($dc ps --quiet seaweedfs)" ]; then
   echo "SeaweedFS container is not running, skipping moving tmp data."
 else
   # Only execute this when we find `*.dat` and/or `*.vif` files in `/tmp`


### PR DESCRIPTION
This is a followup for https://github.com/getsentry/self-hosted/pull/3991 and an alternative of https://github.com/getsentry/self-hosted/pull/3999 that doesn't use a lock file.
