### PR TITLE
fix: remove snuba uptime results consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -463,13 +463,6 @@ services:
     command: subscriptions-scheduler-executor --dataset events_analytics_platform --entity eap_items --auto-offset-reset=latest --no-strict-offset-reset --consumer-group=snuba-eap-items-subscriptions-consumers --followed-consumer-group=eap_items_group --schedule-ttl=60 --stale-threshold-seconds=900 --health-check-file /tmp/health.txt
     healthcheck:
       <<: *file_healthcheck_defaults
-  snuba-uptime-results-consumer:
-    <<: *snuba_defaults
-    command: rust-consumer --storage uptime_monitor_checks --consumer-group snuba-uptime-results --auto-offset-reset=latest --max-batch-time-ms 750 --no-strict-offset-reset --health-check-file /tmp/health.txt
-    healthcheck:
-      <<: *file_healthcheck_defaults
-    profiles:
-      - feature-complete
   symbolicator:
     <<: *restart_policy
     image: "$SYMBOLICATOR_IMAGE"


### PR DESCRIPTION
Saw this error on the self-hosted e2e tests:
```
snuba-uptime-results-consumer-1 | Error: Invalid value for '--storage': 'uptime_monitor_checks' is not one of 'spans', 'metrics_raw', 'errors', 'search_issues', 'generic_metrics_distributions_raw', 'generic_metrics_counters_raw', 'generic_metrics_sets_raw', 'generic_metrics_gauges_raw', 'eap_items', 'groupassignees', 'outcomes_raw', 'querylog', 'functions_raw', 'transactions', 'replays', 'profile_chunks', 'profiles', 'groupedmessages', 'group_attributes'.
```

Seems like we don't need that consumer anymore, since it's moved to EAP.

Refer to https://github.com/getsentry/snuba/pull/7491