### PR TITLE
fix(install): add migrate-pgbouncer.sh to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,7 @@ source install/bootstrap-snuba.sh
 source install/upgrade-postgres.sh
 source install/ensure-correct-permissions-profiles-dir.sh
 source install/set-up-and-migrate-database.sh
+source install/migrate-pgbouncer.sh
 source install/geoip.sh
 source install/setup-js-sdk-assets.sh
 source install/wrap-up.sh


### PR DESCRIPTION
Fix for #4029

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
