### PR TITLE
fix: broken link to Errors-Only Mode docs

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 COMPOSE_PROJECT_NAME=sentry-self-hosted
 # Set COMPOSE_PROFILES to "feature-complete" to enable all features
 # To enable errors monitoring only, set COMPOSE_PROFILES=errors-only
-# See https://develop.sentry.dev/self-hosted/experimental/errors-only/
+# See https://develop.sentry.dev/self-hosted/optional-features/errors-only/
 COMPOSE_PROFILES=feature-complete
 SENTRY_EVENT_RETENTION_DAYS=90
 # You can either use a port number or an IP:PORT combo for SENTRY_BIND

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -92,7 +92,7 @@ if env("SENTRY_SYSTEM_SECRET_KEY"):
 # in your `.env` file. To enable only the error monitoring feature, set
 # `COMPOSE_PROFILES` to `errors-only`.
 #
-# See https://develop.sentry.dev/self-hosted/experimental/errors-only/
+# See https://develop.sentry.dev/self-hosted/optional-features/errors-only/
 SENTRY_SELF_HOSTED_ERRORS_ONLY = env("COMPOSE_PROFILES") != "feature-complete"
 
 # When running in an air-gapped environment, set this to True to entirely disable


### PR DESCRIPTION
Fix broken link.

Should I also create redirect in [sentry-docs](https://github.com/getsentry/sentry-docs) repo? 
Thanks


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
