### PR TITLE
fix: missing SYMBOLICATOR_STATSD_ADDR environment var for symbolicator-cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -481,6 +481,8 @@ services:
   symbolicator-cleanup:
     <<: *restart_policy
     image: "$SYMBOLICATOR_IMAGE"
+    environment:
+      SYMBOLICATOR_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
     command: "cleanup -c /etc/symbolicator/config.yml --repeat 1h"
     volumes:
       - "sentry-symbolicator:/data"


### PR DESCRIPTION
Curious why SH e2e test is failing on Snuba: https://github.com/getsentry/snuba/actions/runs/19374390946/job/55439113104