### PR TITLE
chore: remove some more unused directories

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,13 +46,8 @@ runs:
       shell: bash
       run: |
         ### Inspired by https://github.com/endersonmenezes/free-disk-space ###
-        df -h
         sudo rm -rf /usr/local/.ghcup
-        df -h
-        sudo rm -rf /opt/ghc /opt/cabal
-        df -h
         sudo rm -rf /home/runner/Android /usr/local/lib/android /opt/android /usr/local/android-sdk
-        df -h
         sudo rm -rf /usr/share/dotnet /usr/share/doc/dotnet-*
         df -h
 


### PR DESCRIPTION
We've been experiencing GHA runner out of disk space again lately.

Output from GHA amd64 (ubuntu-latest) runner:
```
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   53G   19G  74% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001

>  sudo rm -rf /usr/local/.ghcup
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   47G   26G  66% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001

>  sudo rm -rf /opt/ghc /opt/cabal
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   47G   26G  66% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001

>  sudo rm -rf /home/runner/Android /usr/local/lib/android /opt/android /usr/local/android-sdk
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   35G   37G  49% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001

>  sudo rm -rf /usr/share/dotnet /usr/share/doc/dotnet-*
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   31G   41G  43% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

Output from GHA arm64 (ubuntu-24.04-arm) runner:
```
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   27G   46G  38% /
tmpfs           7.8G  100K  7.8G   1% /dev/shm
tmpfs           3.2G  1.0M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   13K  128M   1% /sys/firmware/efi/efivars
/dev/sda16      891M   61M  768M   8% /boot
/dev/sda15       98M  6.4M   92M   7% /boot/efi
tmpfs           1.6G   16K  1.6G   1% /run/user/1001

>  sudo rm -rf /usr/local/.ghcup
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   27G   46G  38% /
tmpfs           7.8G  100K  7.8G   1% /dev/shm
tmpfs           3.2G  1.0M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   13K  128M   1% /sys/firmware/efi/efivars
/dev/sda16      891M   61M  768M   8% /boot
/dev/sda15       98M  6.4M   92M   7% /boot/efi
tmpfs           1.6G   16K  1.6G   1% /run/user/1001

>  sudo rm -rf /opt/ghc /opt/cabal
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   27G   46G  38% /
tmpfs           7.8G  100K  7.8G   1% /dev/shm
tmpfs           3.2G  1.0M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   13K  128M   1% /sys/firmware/efi/efivars
/dev/sda16      891M   61M  768M   8% /boot
/dev/sda15       98M  6.4M   92M   7% /boot/efi
tmpfs           1.6G   16K  1.6G   1% /run/user/1001

>  sudo rm -rf /home/runner/Android /usr/local/lib/android /opt/android /usr/local/android-sdk
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   27G   46G  38% /
tmpfs           7.8G  100K  7.8G   1% /dev/shm
tmpfs           3.2G  1.0M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   13K  128M   1% /sys/firmware/efi/efivars
/dev/sda16      891M   61M  768M   8% /boot
/dev/sda15       98M  6.4M   92M   7% /boot/efi
tmpfs           1.6G   16K  1.6G   1% /run/user/1001

>  sudo rm -rf /usr/share/dotnet /usr/share/doc/dotnet-*
>  df -h

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   24G   49G  33% /
tmpfs           7.8G  100K  7.8G   1% /dev/shm
tmpfs           3.2G  1.0M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
efivarfs        128M   13K  128M   1% /sys/firmware/efi/efivars
/dev/sda16      891M   61M  768M   8% /boot
/dev/sda15       98M  6.4M   92M   7% /boot/efi
tmpfs           1.6G   16K  1.6G   1% /run/user/1001
```