### PR TITLE
Add UPTIME_CHECKER_ALLOW_INTERNAL_IPS on .env

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,7 @@ RELAY_IMAGE=ghcr.io/getsentry/relay:nightly
 SYMBOLICATOR_IMAGE=ghcr.io/getsentry/symbolicator:nightly
 TASKBROKER_IMAGE=ghcr.io/getsentry/taskbroker:nightly
 VROOM_IMAGE=ghcr.io/getsentry/vroom:nightly
+UPTIME_CHECKER_ALLOW_INTERNAL_IPS=false
 UPTIME_CHECKER_IMAGE=ghcr.io/getsentry/uptime-checker:nightly
 HEALTHCHECK_INTERVAL=30s
 HEALTHCHECK_TIMEOUT=1m30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -794,7 +794,7 @@ services:
       UPTIME_CHECKER_RESULTS_KAFKA_CLUSTER: kafka:9092
       UPTIME_CHECKER_REDIS_HOST: redis://redis:6379
       # Set to `true` will allow uptime checks against private IP addresses
-      UPTIME_CHECKER_ALLOW_INTERNAL_IPS: "false"
+      UPTIME_CHECKER_ALLOW_INTERNAL_IPS: "$UPTIME_CHECKER_ALLOW_INTERNAL_IPS"
       # The number of times to retry failed checks before reporting them as failed
       UPTIME_CHECKER_FAILURE_RETRIES: "1"
       # DNS name servers to use when making checks in the http checker.


### PR DESCRIPTION

<!-- Describe your PR here. -->
This PR allows `UPTIME_CHECKER_ALLOW_INTERNAL_IPS` to be added on env file and used on docker compose uptime service.

Fixes https://github.com/getsentry/self-hosted/issues/4053


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
