### PR TITLE
Add shm_size configuration back to postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: "trust"
     volumes:
       - "sentry-postgres:/var/lib/postgresql/data"
+    shm_size: 256m
   pgbouncer:
     <<: *restart_policy
     image: "edoburu/pgbouncer:v1.24.1-p1"


### PR DESCRIPTION

For routine vacuum operations, some shm size is still required. This was removed with the introduction of seaweedfs:

<img width="928" height="48" alt="image" src="https://github.com/user-attachments/assets/4ce314d4-fe95-4eb2-8425-b2d8a02d4560" />


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
