### PR TITLE
chore: guard unit-test.sh from being invoked by users

### DIFF
--- a/unit-test.sh
+++ b/unit-test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# The test should not be run by regular users. This should only be run in CI or by developers.
+if [[ "$CI" != "true" ]]; then
+  echo "This script is intended to be run in CI or by developers only."
+  exit 1
+fi
+
 export REPORT_SELF_HOSTED_ISSUES=0 # will be over-ridden in the relevant test
 
 FORCE_CLEAN=1 "./scripts/reset.sh"


### PR DESCRIPTION
Although I only seen one user reported this destroyed their self-hosted instance, and I initially thought to move the script elsewhere, I suppose this is a good alternative to really guard it.

