### PR TITLE
chore: ask installation type on problem report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem-report.yml
+++ b/.github/ISSUE_TEMPLATE/problem-report.yml
@@ -49,6 +49,15 @@ body:
           required: true
     validations:
       required: true
+  - type: input
+    id: installation_type
+    attributes:
+      label: Installation Type
+      placeholder: Fresh install / Upgrade from 24.8.0 to 25.5.1
+      description: |
+        Are you filing this issue for a fresh install or an upgrade?
+    validations:
+      required: true
   - type: textarea
     id: repro
     attributes:


### PR DESCRIPTION
This is meant to save some time, usually this is one thing I ask to users when they encountered a problem.

