### PR TITLE
fix: missing 'SENTRY_SYSTEM_SECRET_KEY' declaration on Docker Compose block

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ x-sentry-defaults: &sentry_defaults
     SENTRY_EVENT_RETENTION_DAYS:
     SENTRY_MAIL_HOST:
     SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE:
+    SENTRY_SYSTEM_SECRET_KEY:
     SENTRY_STATSD_ADDR: "${STATSD_ADDR:-}"
   volumes:
     - "sentry-data:/data"


### PR DESCRIPTION
Closes https://github.com/getsentry/self-hosted/issues/4077
