### PR TITLE
Fix bootstrap conditions to strip carriage returns and add more tests

### DIFF
--- a/_unit-test/bootstrap-s3-nodestore-test.sh
+++ b/_unit-test/bootstrap-s3-nodestore-test.sh
@@ -13,4 +13,24 @@ for i in $(seq 1 5); do
   source install/bootstrap-s3-nodestore.sh
 done
 
+s3_cmd="$dc exec seaweedfs s3cmd --access_key=sentry --secret_key=sentry --no-ssl --region=us-east-1 --host=seaweedfs:8333 --host-bucket=seaweedfs:8333/%(bucket)"
+
+if ! $s3_cmd ls | grep -q "s3://nodestore"; then
+  echo "Error: Nodestore bucket not found"
+  exit 1
+fi
+
+test_file="s3-test-$(date +%s).txt"
+$dc exec seaweedfs sh -c "echo 'sentry-test-content' > /tmp/$test_file"
+$s3_cmd put "/tmp/$test_file" "s3://nodestore/$test_file" > /dev/null
+
+file_count=$($s3_cmd ls "s3://nodestore/$test_file" | grep -c "$test_file")
+if [[ "$file_count" -ne 1 ]]; then
+  echo "Error: Test file was not found in the bucket."
+  exit 1
+fi
+
+# Manual cleanup, otherwise `create-docker-volumes.sh` will fail
+$dc down -v --remove-orphans
+
 report_success

--- a/_unit-test/bootstrap-s3-profiles-test.sh
+++ b/_unit-test/bootstrap-s3-profiles-test.sh
@@ -24,8 +24,15 @@ for i in $(seq 1 5); do
   source install/bootstrap-s3-profiles.sh
 done
 
+s3_cmd="$dc exec seaweedfs s3cmd --access_key=sentry --secret_key=sentry --no-ssl --region=us-east-1 --host=seaweedfs:8333 --host-bucket=seaweedfs:8333/%(bucket)"
+
+if ! $s3_cmd ls | grep -q "s3://profiles"; then
+  echo 'Error: Profiles bucket not found'
+  exit 1
+fi
+
 # Ensure that the files have been migrated to SeaweedFS
-migrated_files_count=$($dc exec seaweedfs s3cmd --access_key=sentry --secret_key=sentry --no-ssl --region=us-east-1 --host=seaweedfs:8333 --host-bucket="seaweedfs:8333/%(bucket)" ls s3://profiles/ | wc -l)
+migrated_files_count=$($s3_cmd ls s3://profiles/ | wc -l)
 if [[ "$migrated_files_count" -ne 1000 ]]; then
   echo "Error: Expected 1000 migrated files, but found $migrated_files_count"
   exit 1

--- a/_unit-test/multiple-bootstrap-s3-test.sh
+++ b/_unit-test/multiple-bootstrap-s3-test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+source _unit-test/_test_setup.sh
+source install/dc-detect-version.sh
+source install/create-docker-volumes.sh
+
+# Set the flag to apply automatic updates
+export APPLY_AUTOMATIC_CONFIG_UPDATES=1
+
+source install/bootstrap-s3-nodestore.sh
+source install/bootstrap-s3-profiles.sh
+
+s3_cmd="$dc exec seaweedfs s3cmd --access_key=sentry --secret_key=sentry --no-ssl --region=us-east-1 --host=seaweedfs:8333 --host-bucket=seaweedfs:8333/%(bucket)"
+
+bucket_list=$($s3_cmd ls)
+if ! echo "$bucket_list" | grep -q "s3://profiles"; then
+  echo 'Error: Profiles bucket not found'
+  exit 1
+fi
+
+if ! echo "$bucket_list" | grep -q "s3://nodestore"; then
+  echo "Error: Nodestore bucket not found"
+  exit 1
+fi
+
+# Trying to run nodestore bootstrap again should run fine even with multiple buckets
+source install/bootstrap-s3-nodestore.sh
+
+# Manual cleanup, otherwise `create-docker-volumes.sh` will fail
+$dc down -v --remove-orphans
+
+report_success

--- a/install/bootstrap-s3-nodestore.sh
+++ b/install/bootstrap-s3-nodestore.sh
@@ -7,7 +7,7 @@ s3cmd="$dc exec seaweedfs s3cmd"
 
 bucket_list=$($s3cmd --access_key=sentry --secret_key=sentry --no-ssl --region=us-east-1 --host=localhost:8333 --host-bucket='localhost:8333/%(bucket)' ls)
 
-if ! echo "$bucket_list" | grep -q "s3://nodestore"; then
+if ! echo "$bucket_list" | tr -d '\r' | grep -q "s3://nodestore"; then
   apply_config_changes_nodestore=0
   # Only touch if no existing nodestore config is found
   if ! grep -q "SENTRY_NODESTORE" $SENTRY_CONFIG_PY; then

--- a/install/bootstrap-s3-profiles.sh
+++ b/install/bootstrap-s3-profiles.sh
@@ -19,7 +19,7 @@ if [[ "$COMPOSE_PROFILES" == "feature-complete" ]]; then
 
   bucket_list=$($s3cmd --access_key=sentry --secret_key=sentry --no-ssl --region=us-east-1 --host=localhost:8333 --host-bucket='localhost:8333/%(bucket)' ls)
 
-  if ! echo "$bucket_list" | grep -q "s3://profiles"; then
+  if ! echo "$bucket_list" | tr -d '\r' | grep -q "s3://profiles"; then
     apply_config_changes_profiles=0
     # Only touch if no existing profiles config is found
     if ! grep -q "filestore.profiles-backend" $SENTRY_CONFIG_YML; then


### PR DESCRIPTION
<!-- Describe your PR here. -->
While upgrading Sentry to 25.11.1 from 25.10.0, I was running into a bug in the bootstrap scripts where the script would attempt to recreate nodestore even though it already existed.
 
```
  - 'ERROR: Bucket ''nodestore'' already exists'
  - >-
    ERROR: S3 error: 409 (BucketAlreadyExists): The requested bucket name is not
    available. The bucket name can not be an existing collection, and the bucket
    namespace is shared by all users of the system. Please select a different
    name and try again.
  - ''
  - Error in install/bootstrap-s3-nodestore.sh:64.
  - >-
    '$s3cmd --access_key=sentry --secret_key=sentry --no-ssl --region=us-east-1
    --host=localhost:8333 --host-bucket='localhost:8333/%(bucket)' mb
    s3://nodestore' exited with status 13
  - '-> ./install.sh:main:39'
  - '--> install/bootstrap-s3-nodestore.sh:source:64'
  ```

After some debugging I came to the conclusion that 
```
bucket_list=$($s3cmd --access_key=sentry --secret_key=sentry --no-ssl --region=us-east-1 --host=localhost:8333 --host-bucket='localhost:8333/%(bucket)' ls)
```
was returning a carriage return encoded in the output, which caused this check `if ! echo "$bucket_list" | grep -q "s3://nodestore";` to fail.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
