### PR TITLE
DO NOT MERGE: Debug rm time

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,10 +46,14 @@ runs:
       shell: bash
       run: |
         ### Inspired by https://github.com/endersonmenezes/free-disk-space ###
-        sudo rm -rf /usr/local/.ghcup
-        sudo rm -rf /home/runner/Android /usr/local/lib/android /opt/android /usr/local/android-sdk
-        sudo rm -rf /usr/share/dotnet /usr/share/doc/dotnet-*
         df -h
+        time sudo rm -rf /usr/local/.ghcup
+        df -h
+        time sudo rm -rf /home/runner/Android /usr/local/lib/android /opt/android /usr/local/android-sdk
+        df -h
+        time sudo rm -rf /usr/share/dotnet /usr/share/doc/dotnet-*
+        df -h
+        exit 1
 
     - name: Setup uv
       uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5


### PR DESCRIPTION
Just making sure https://github.com/getsentry/self-hosted/pull/4046 is not adding lots of time to GHA time.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
