### PR TITLE
feat: switch nodestore-s3 package to getsentry org

### DIFF
--- a/sentry/Dockerfile
+++ b/sentry/Dockerfile
@@ -1,7 +1,7 @@
 ARG SENTRY_IMAGE
 FROM ${SENTRY_IMAGE}
 
-RUN pip install git+https://github.com/getsentry/sentry-nodestore-s3.git@508246183499908232517200229ad5118e147331
+RUN pip install https://github.com/getsentry/sentry-nodestore-s3/archive/main.zip
 
 COPY . /usr/src/sentry
 


### PR DESCRIPTION
We moved the sentry-nodestore-s3 package under getsentry org (https://github.com/getsentry/sentry-nodestore-s3).


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
