### PR TITLE
chore(deps): bump seaweedfs version to 3.97

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,7 +244,7 @@ services:
       retries: 30
   seaweedfs:
     <<: *restart_policy
-    image: "chrislusf/seaweedfs:3.96_large_disk"
+    image: "chrislusf/seaweedfs:3.97_large_disk"
     entrypoint: "weed"
     command: >-
         server


### PR DESCRIPTION
An attempt to fix https://github.com/getsentry/self-hosted/issues/4074

Turns out the error message mentioned in https://github.com/getsentry/self-hosted/issues/4074 is the same as https://github.com/seaweedfs/seaweedfs/issues/7060, fixed in version 3.97. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
