### PR TITLE
ci: Fix changelog-preview permissions

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
 
 jobs:
   changelog-preview:


### PR DESCRIPTION
New versions need `statuses: check` for the quiet workflow