### PR TITLE
feat: Provide blank environment variables for AWS SES relay

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,11 @@ services:
       - "sentry-smtp:/var/spool/exim4"
       - "sentry-smtp-log:/var/log/exim4"
     environment:
-      - MAILNAME=${SENTRY_MAIL_HOST:-}
+      MAILNAME: ${SENTRY_MAIL_HOST:-}
+      # Refer to https://develop.sentry.dev/self-hosted/configuration/email/#as-aws-ses-relay
+      SES_USER:
+      SES_PASSWORD:
+      SES_REGION:
   memcached:
     <<: *restart_policy
     image: "memcached:1.6.26-alpine"


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry-docs/pull/16293

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
