### PR TITLE
Bump nginx 1.29.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -682,7 +682,7 @@ services:
     <<: *restart_policy
     ports:
       - "$SENTRY_BIND:80/tcp"
-    image: "nginx:1.29.1-alpine"
+    image: "nginx:1.29.5-alpine"
     volumes:
       - type: bind
         read_only: true


### PR DESCRIPTION
nginx 1.29.5 changelog:
```
    *) Security: an attacker might inject plain text data in the response
       from an SSL backend (CVE-2026-1642).
```

Although it does not affect self-hosted as it does not use ssl backend and it's internal, but let's prevent annoying security scanners trigger this :)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
