### PR TITLE
fix: add "organizations:on-demand-metrics-extraction" ff to enable metric alerts

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -400,6 +400,7 @@ SENTRY_FEATURES.update(
             "organizations:insights-modules-use-eap",
             "organizations:standalone-span-ingestion",
             "organizations:starfish-mobile-appstart",
+            "organizations:on-demand-metrics-extraction",
             "projects:span-metrics-extraction",
             "projects:span-metrics-extraction-addons",
         )


### PR DESCRIPTION
Required because of this https://github.com/getsentry/sentry/commit/57ece381eaba8d9e4e3a01e5410a6f37e411b56f



<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
