### PR TITLE
Use docker-compose shipped in GHA runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Get Compose
-        uses: ./get-compose-action
-
       - name: Unit Tests
         run: ./unit-test.sh
 

--- a/action.yaml
+++ b/action.yaml
@@ -84,9 +84,6 @@ runs:
           fi
         fi
 
-    - name: Get Compose
-      uses: getsentry/self-hosted/get-compose-action@master
-
     - name: Compute Docker Volume Cache Keys
       id: cache_key
       shell: bash


### PR DESCRIPTION
Continuation of https://github.com/getsentry/self-hosted/pull/4179#pullrequestreview-3824491025 .

`docker-compose` has been stabilized for a while without breaking changes in main commands, I guess we can use whatever `docker-compose` version which GHA runners ship.

Also as it has been more than two years `docker-ce` package (in linux environments at least) is dependent on `docker-compose-plugin`, therefore upgrading `docker-compose-plugin` has been a lot easier for users.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
