### PR TITLE
fix(workflows): Prevent shell injection in fast-revert workflow

### DIFF
--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -30,11 +30,17 @@ jobs:
           committer_email: bot@sentry.io
           token: ${{ secrets.BUMP_SENTRY_TOKEN }}
       - name: comment on failure
+        env:
+          GH_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          REPO_ID: ${{ github.event.repository.id }}
+          ISSUE_NUMBER: ${{ github.event.number || github.event.inputs.pr }}
         run: |
           curl \
               --silent \
               -X POST \
-              -H 'Authorization: token ${{ secrets.BUMP_SENTRY_TOKEN }}' \
-              -d'{"body": "revert failed (conflict? already reverted?) -- [check the logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
-              https://api.github.com/repositories/${{ github.event.repository.id }}/issues/${{ github.event.number || github.event.inputs.pr }}/comments
+              -H "Authorization: token $GH_TOKEN" \
+              -d "{\"body\": \"revert failed (conflict? already reverted?) -- [check the logs](https://github.com/$REPO/actions/runs/$RUN_ID)\"}" \
+              "https://api.github.com/repositories/$REPO_ID/issues/$ISSUE_NUMBER/comments"
         if: failure()


### PR DESCRIPTION
## Summary

This PR fixes a shell injection vulnerability in the `fast-revert.yml` GitHub Actions workflow.

### Vulnerability

The "comment on failure" step directly interpolates GitHub context values (`${{ github.event.inputs.pr }}`, `${{ github.repository }}`, `${{ github.run_id }}`, etc.) inside a `run:` block. This pattern is flagged by the Semgrep rule [yaml.github-actions.security.run-shell-injection.run-shell-injection](https://semgrep.dev/r/yaml.github-actions.security.run-shell-injection.run-shell-injection).

When GitHub context values are interpolated directly into shell commands, a malicious actor could craft input (e.g., a specially crafted PR number or repository name) that breaks out of the intended shell context and executes arbitrary commands.

### Fix

Replace direct context interpolation with environment variables. The GitHub context values are safely assigned to `env:` variables, which are then referenced as shell variables (e.g., `$GH_TOKEN`, `$REPO`). This prevents shell injection because environment variable expansion does not allow command substitution.

### References

- Semgrep rule: https://semgrep.dev/r/yaml.github-actions.security.run-shell-injection.run-shell-injection
- Similar fix in taskbroker: getsentry/taskbroker#556 (VULN-1096)
- Similar fix in snuba: getsentry/snuba#7747 (VULN-1101)
- Linear issue: https://linear.app/getsentry/issue/DI-967