### PR TITLE
ref: restore unpinned actions

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   changelog-preview:
-    uses: getsentry/craft/.github/workflows/changelog-preview.yml@f4889d04564e47311038ecb6b910fef6b6cf1363 # 2.25.0
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
     secrets: inherit

--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.BUMP_SENTRY_TOKEN }}
-      - uses: getsentry/action-fast-revert@35b4b6c1f8f91b5911159568b3b15e531b5b8174 # v2.0.1
+      - uses: getsentry/action-fast-revert@v2
         with:
           pr: ${{ github.event.number || github.event.inputs.pr }}
           co_authored_by: ${{ github.event.inputs.co_authored_by || format('{0} <{1}+{0}@users.noreply.github.com>', github.event.sender.login, github.event.sender.id) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - name: Prepare release
         id: prepare-release
-        uses: getsentry/craft@f4889d04564e47311038ecb6b910fef6b6cf1363 # 2.25.0
+        uses: getsentry/craft@v2
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: getsentry/action-release@dab6548b3c03c4717878099e43782cf5be654289 # v3.5.0
+      - uses: getsentry/action-release@v3
         env:
           SENTRY_ORG: self-hosted
           SENTRY_PROJECT: installer

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,5 @@
 name: "Sentry self-hosted end-to-end tests"
+description: "Runs end-to-end tests against a self-hosted instance built from the current branch. You can optionally specify a custom image to test against as well."
 inputs:
   project_name:
     required: false
@@ -59,6 +60,8 @@ runs:
         # we just cache the venv-dir directly in action-setup-venv
         enable-cache: false
 
+    # NOTE(aldy505): Specifically pinned to 3.1.0
+    # See https://github.com/getsentry/action-setup-venv/issues/28
     - uses: getsentry/action-setup-venv@6e8aebf461914919d9de6e3082669d6bfecc400c # v3.1.0
       with:
         python-version: "3.12"


### PR DESCRIPTION
Previously we have pinned actions for those created by 'getsentry/', now it's a maintenance burden to approve & merge every dependabot PR. Let's just unpin them. Therefore making Burak's life easier too.

