### PR TITLE
fix(install): gracefully handle missing containers in minimize-downtime

### DIFF
--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -3,8 +3,18 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
 
   # Start the whole setup, except nginx and relay.
   start_service_and_wait_ready --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
-  $dc restart relay
-  $dc exec -T nginx nginx -s reload
+
+  if [ -n "$($dc ps -q relay 2>/dev/null)" ]; then
+    $dc restart relay
+  else
+    echo "Relay container not found, skipping restart."
+  fi
+
+  if [ -n "$($dc ps -q nginx 2>/dev/null)" ]; then
+    $dc exec -T nginx nginx -s reload || true
+  else
+    echo "Nginx container not found, skipping reload."
+  fi
 
   $CONTAINER_ENGINE run --rm --network="${COMPOSE_PROJECT_NAME}_default" alpine ash \
     -c 'while [[ "$(wget -T 1 -q -O- http://web:9000/_health/)" != "ok" ]]; do sleep 0.5; done'


### PR DESCRIPTION
Fixes #3954. 

When [install.sh](cci:7://file:///Users/shameem/Documents/self-hosted/install.sh:0:0-0:0) is run with `MINIMIZE_DOWNTIME=1`, the script blindly attempts to run `docker compose restart relay` and `docker compose exec nginx nginx -s reload`. If the `relay` container was removed or was completely shut down prior to running the installer, docker compose aggressively exits with code 1, which causes the bash script to crash. 

This commit checks whether the relevant containers actually exist via `docker compose ps` before executing the restart/reload, completely resolving the uncaught crash scenario while continuing to natively recreate the missing containers correctly at the end of the script using `start_service_and_wait_ready`.
