### PR TITLE
fix: use default buildx builder to resolve local images during build

### DIFF
--- a/install/build-docker-images.sh
+++ b/install/build-docker-images.sh
@@ -1,6 +1,16 @@
 echo "${_group}Building and tagging Docker images ..."
 
 echo ""
+
+# Use the default buildx builder to ensure locally built images
+# (e.g., sentry-self-hosted-local) are accessible during the build.
+# Non-default builders using the docker-container driver run in isolation
+# and cannot resolve local images, causing "pull access denied" errors.
+# See: https://github.com/moby/buildkit/issues/4162
+if [ "$CONTAINER_ENGINE" = "docker" ]; then
+  export BUILDX_BUILDER=default
+fi
+
 # Build any service that provides the image sentry-self-hosted-local first,
 # as it is used as the base image for sentry-cleanup-self-hosted-local.
 $dcb web


### PR DESCRIPTION
## Problem

When the active buildx builder uses the `docker-container` driver (which is increasingly common as Docker defaults to BuildKit), services like `sentry-cleanup` that depend on locally built images (`sentry-self-hosted-local`) via `FROM ${BASE_IMAGE}` fail with:

```
failed to solve: sentry-self-hosted-local: failed to resolve source metadata for
docker.io/library/sentry-self-hosted-local:latest: pull access denied
```

The `docker-container` driver runs in isolation and cannot access host-local images, so BuildKit attempts to pull from Docker Hub instead.

This has been reported multiple times: #3476, #2557, #2302, #2248, #1781.

## Solution

Set `BUILDX_BUILDER=default` in `install/build-docker-images.sh` before building images. The `default` builder uses the `docker` driver, which has direct access to the local image store.

- Only applied when `CONTAINER_ENGINE=docker` (no effect on Podman)
- Scoped to the build script only
- Does not use the deprecated `DOCKER_BUILDKIT=0` flag
- References upstream issue: https://github.com/moby/buildkit/issues/4162