### PR TITLE
feat: run SeaweedFS admin and worker instance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,7 +248,7 @@ services:
       retries: 30
   seaweedfs:
     <<: *restart_policy
-    image: "chrislusf/seaweedfs:4.09_large_disk"
+    image: "chrislusf/seaweedfs:4.17_large_disk"
     entrypoint: "weed"
     command: >-
         server
@@ -292,6 +292,22 @@ services:
       timeout: 20s
       retries: 5
       start_period: 60s
+  seaweedfs-admin:
+    <<: *restart_policy
+    image: "chrislusf/seaweedfs:4.17_large_disk"
+    entrypoint: "weed"
+    command: >-
+      admin
+      -port=23646
+      -master=seaweedfs:9333
+  seaweedfs-worker:
+    <<: *restart_policy
+    image: "chrislusf/seaweedfs:4.17_large_disk"
+    entrypoint: "weed"
+    command: >-
+      worker
+      -admin=seaweedfs-admin:23646
+      -jobType=all
   snuba-api:
     <<: *snuba_defaults
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,7 +272,6 @@ services:
         -volume.readMode=redirect
         -volume.port=8080
         -volume.port.grpc=18080
-        -ip=127.0.0.1
         -ip.bind=0.0.0.0
         -webdav=false
     environment:
@@ -300,6 +299,9 @@ services:
       admin
       -port=23646
       -master=seaweedfs:9333
+    depends_on:
+      seaweedfs:
+        <<: *depends_on-healthy
   seaweedfs-worker:
     <<: *restart_policy
     image: "chrislusf/seaweedfs:4.17_large_disk"
@@ -308,6 +310,9 @@ services:
       worker
       -admin=seaweedfs-admin:23646
       -jobType=all
+    depends_on:
+      seaweedfs-admin:
+        <<: *depends_on-default
   snuba-api:
     <<: *snuba_defaults
     healthcheck:


### PR DESCRIPTION
Cleanup using the 'worker' service weren't running on the default setup with 'server' mode. This PR adds both admin and worker to solve that.

Fixes https://github.com/getsentry/self-hosted/issues/4106

