### PR TITLE
fix: disable a few more new clickhouse tables

### DIFF
--- a/clickhouse/config.xml
+++ b/clickhouse/config.xml
@@ -15,6 +15,10 @@
     <!-- Update: Required for newer versions of Clickhouse -->
     <session_log remove="remove"/>
     <part_log remove="remove"/>
+    <query_views_log remove="remove"/>
+    <processors_profile_log remove="remove"/>
+    <error_log remove="remove"/>
+    <latency_log remove="remove"/>
 
     <allow_nullable_key>1</allow_nullable_key>
 


### PR DESCRIPTION
Closes #4266


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
