### PR TITLE
feat(ci): cancel in-progress PR workflows on new commit push

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,6 +9,10 @@ on:
       - "**.sh"
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
this adds concurrency cancellation to pull_request workflows so that pushing a new commit to a PR automatically cancels any still-running workflow from the previous commit

99% of the time if you push a new commit you don't care about the previous workflow if its still running

**we already do this for all sentry+getsentry pull_request workflows**

we (devinfra) can't measure this yet but this would greatly help decrease org-wide runner queue pressure!