### PR TITLE
fix(nginx): add resolver and upstream resolve to prevent stale IP rou…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -65,13 +65,20 @@ http {
 	proxy_read_timeout 30s;
 	proxy_send_timeout 5s;
 
+	# Resolve container hostnames through Docker DNS so upstream IP changes
+	# (after container recreation) are picked up without requiring nginx restart.
+	resolver 127.0.0.11 valid=30s;
+	resolver_timeout 5s;
+
 	upstream relay {
-		server relay:3000;
+		zone relay 64k;
+		server relay:3000 resolve;
 		keepalive 2;
 	}
 
 	upstream sentry {
-		server web:9000;
+		zone sentry 64k;
+		server web:9000 resolve;
 		keepalive 2;
 	}
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Why

In the default self-hosted Docker Compose deployment, nginx proxies traffic to
the `relay` and `web` services by hostname.

When those containers are recreated and receive a new container IP, nginx may
continue using a stale upstream address until nginx itself is reloaded or
restarted.

Observed symptom:
- `connect() failed (...) while connecting to upstream`
- nginx attempts to reach a stale upstream container IP

## What changed

- Added a DNS resolver in `nginx.conf`
- Enabled runtime DNS re-resolution for upstream backends:
  - `relay:3000 resolve`
  - `web:9000 resolve`
- Added `zone` directives required by nginx for dynamic upstream resolution

## Config details

- `resolver 127.0.0.11 valid=30s;`
- `resolver_timeout 5s;`
- `zone relay 64k;`
- `zone sentry 64k;`

## Why these values

- `127.0.0.11`: Docker embedded DNS in the default self-hosted container network
- `valid=30s`: balances recovery time and DNS lookup overhead
- `resolver_timeout=5s`: avoids long stalls on DNS issues
- `64k zone`: sufficient for these small upstream groups

## Test plan

- [x] nginx starts successfully with the updated config
- [x] traffic is routed correctly to `relay` and `web`
- [x] after recreating `relay`, nginx no longer keeps using a stale upstream IP
- [x] manual local verification of continued ingestion after backend IP change

## Notes

This change is intended to make nginx more resilient to backend container IP
changes in the default self-hosted Docker Compose setup.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
