### PR TITLE
ref(template): Remove task for updating relocation release tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -26,7 +26,5 @@ body:
           - [ ] [Create the next release issue](https://github.com/getsentry/self-hosted/issues/new?assignees=&labels=&projects=&template=release.yml) and link it from this one.
             - _replace with link_
           - [ ] Update the [release issue template](https://github.com/getsentry/self-hosted/blob/master/.github/ISSUE_TEMPLATE/release.yml).
-          - [ ] Create a PR to update relocation release tests to add the new version.
-            - _replace with link_
     validations:
       required: true


### PR DESCRIPTION
Removed the task to create a PR for updating relocation release tests, because we don't really look at this anymore.
