### PR TITLE
fix(docker): install custom packages into runtime venv

### DIFF
--- a/sentry/Dockerfile
+++ b/sentry/Dockerfile
@@ -1,7 +1,7 @@
 ARG SENTRY_IMAGE
 FROM ${SENTRY_IMAGE}
 
-RUN pip install https://github.com/getsentry/sentry-nodestore-s3/archive/main.zip
+RUN /.venv/bin/pip install https://github.com/getsentry/sentry-nodestore-s3/archive/main.zip
 
 COPY . /usr/src/sentry
 
@@ -11,5 +11,5 @@ RUN if [ -s /usr/src/sentry/enhance-image.sh ]; then \
 
 RUN if [ -s /usr/src/sentry/requirements.txt ]; then \
     echo "sentry/requirements.txt is deprecated, use sentry/enhance-image.sh - see https://develop.sentry.dev/self-hosted/#enhance-sentry-image"; \
-    pip install -r /usr/src/sentry/requirements.txt; \
+    /.venv/bin/pip install -r /usr/src/sentry/requirements.txt; \
     fi


### PR DESCRIPTION
 ## Summary

  This installs custom Python packages into Sentry's runtime virtualenv instead of the
  system Python.

  `self-hosted` runs Sentry from `/.venv`, but `sentry/Dockerfile` was installing the
  bundled nodestore extension with `pip`, which targets the system interpreter. That can
  leave custom packages unavailable at runtime and cause the `web` service to fail during
  startup.

  ## Root cause

  The image build used:

  ```dockerfile
  RUN pip install ...
```

  while the actual Sentry runtime uses /.venv.

  In my case, this caused the nodestore backend package to be installed outside the runtime
  environment, which led to repeated web worker exits and an unhealthy web container.

  ## Fix

  Use /.venv/bin/pip for custom package installation in sentry/Dockerfile.

  This updates:

  - the nodestore extension install step
  - the optional requirements.txt install step

  ## Validation

  After rebuilding the image and restarting the stack:

  - the custom package is installed into /.venv
  - web workers stop exiting during startup
  - sentry-self-hosted-web-1 becomes healthy

  <!--

    Sentry employees and contractors can delete or ignore the following.

  -->

  ### Legal Boilerplate

  Look, I get it. The entity doing business as "Sentry" was incorporated in the State of
  Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in
  order to utilize my contributions in this here PR. So here's the deal: I retain all
  rights, title and interest in and to my contributions, and by keeping this boilerplate
  intact I confirm that Sentry can use, modify, copy, and redistribute my contributions,
  under Sentry's choice of terms.zhem