### PR TITLE
ref(relay): Remove healthcheck from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -726,7 +726,7 @@ services:
         <<: *depends_on-healthy
         restart: true
       relay:
-        <<: *depends_on-healthy
+        <<: *depends_on-default
         restart: true
   relay:
     <<: [*restart_policy, *pull_policy]
@@ -749,9 +749,6 @@ services:
         <<: *depends_on-healthy
       web:
         <<: *depends_on-healthy
-    healthcheck:
-      <<: *healthcheck_defaults
-      test: ["CMD", "/bin/relay", "healthcheck"]
   taskbroker:
     <<: [*restart_policy, *pull_policy]
     image: "$TASKBROKER_IMAGE"


### PR DESCRIPTION
The health checks constantly get mis-identified by users as a problem, when they are just the effect of a problem downstream (e.g. connectivity issues, project configs not available ...).

In the docker compose environment the healthcheck itself makes little sense. If health checks are failing, Sentry is down. If there is no health check and a problem in the system, Sentry is down.

Docker compose does support almost none of the nuance Kubernetes allows for in health checks, and the self hosted install is not load balancing between multiple instances of Relay.

There is little point in having these health checks + they lead to constant requests and questions -> turn them off.

It may make sense to replace the health check with a liveness probe instead, but even these are not handled well by docker compose. Ordering of services should be good enough by relying on the `started` flag.