### PR TITLE
fix: force disable HTTP(S) proxy for seaweedfs services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,11 @@ x-file-healthcheck: &file_healthcheck_defaults
   timeout: "$HEALTHCHECK_FILE_TIMEOUT"
   retries: $HEALTHCHECK_FILE_RETRIES
   start_period: "$HEALTHCHECK_FILE_START_PERIOD"
+x-force-no-proxy: &force_no_proxy
+  HTTP_PROXY: ""
+  HTTPS_PROXY: ""
+  http_proxy: ""
+  https_proxy: ""
 x-sentry-defaults: &sentry_defaults
   <<: [*restart_policy, *pull_policy]
   image: sentry-self-hosted-local
@@ -275,6 +280,7 @@ services:
         -ip.bind=0.0.0.0
         -webdav=false
     environment:
+      <<: *force_no_proxy
       AWS_ACCESS_KEY_ID: sentry
       AWS_SECRET_ACCESS_KEY: sentry
     volumes:
@@ -299,6 +305,8 @@ services:
       admin
       -port=23646
       -master=seaweedfs:9333
+    environment:
+      <<: *force_no_proxy
     depends_on:
       seaweedfs:
         <<: *depends_on-healthy
@@ -310,6 +318,8 @@ services:
       worker
       -admin=seaweedfs-admin:23646
       -jobType=all
+    environment:
+      <<: *force_no_proxy
     depends_on:
       seaweedfs-admin:
         <<: *depends_on-default


### PR DESCRIPTION
This is an attempt to fix #4300 where SeaweedFS is unable to start successfully if HTTP(S)_PROXY vars are set.

If the host container runtime sets these variables, for example behind a corporate proxy, SeaweedFS services are unable to talk to each other by default. Since they have no business talking to the outside world, just force clear these variables.

This is not the first time those vars cause a weird problem, so I opted to put them in an anchored block for easy inclusion into however many services these might be required in. (Maybe it would be a good way to simplify the whole no_proxy config in the README too?)

Ping @aldy505 for attention

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
