### PR TITLE
Bump postgres 14.23-bookworm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
   postgres:
     <<: *restart_policy
     # Using the same postgres version as Sentry dev for consistency purposes
-    image: "postgres:14.22-bookworm"
+    image: "postgres:14.23-bookworm"
     healthcheck:
       <<: *healthcheck_defaults
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided


### PR DESCRIPTION
https://www.postgresql.org/docs/release/14.23/

```
# Using the same postgres version as Sentry dev for consistency purposes
```
Should we wait for sentry.io upgrade?

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
