### PR TITLE
Clean up statsd monitoring configuration comments

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -530,8 +530,6 @@ JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.
 # By default, Sentry uses dummy statsd monitoring backend that is a no-op.
 # If you have a statsd server, you can utilize that to monitor self-hosted
 # Sentry for "sentry"-related containers.
-#
-# To start, uncomment the following line and adjust the options as needed.
 
 SENTRY_STATSD_ADDR = env("SENTRY_STATSD_ADDR")
 if SENTRY_STATSD_ADDR:


### PR DESCRIPTION
Removed commented instructions for enabling statsd monitoring.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
