### PR TITLE
fix: prevent argument too long error on self-hosted error reports due to breadcrumbs too long

### DIFF
--- a/_unit-test/error-handling-test.sh
+++ b/_unit-test/error-handling-test.sh
@@ -19,9 +19,11 @@ send_envelope() {
 export -f send_envelope
 echo "Testing initial send_event"
 export log_file=test_log.txt
+expected_filename='sentry-envelope-f73e4da437c42a1d28b86a81ebcff35d'
+rm -f "/tmp/$expected_filename"
 echo "Test Logs" >"$log_file"
 echo "Error Msg" >>"$log_file"
-breadcrumbs=$(generate_breadcrumb_json | sed '$d' | $jq -s -c)
+breadcrumbs=$(collect_breadcrumbs)
 SEND_EVENT_RESPONSE=$(
   send_event \
     "'foo' exited with status 1" \
@@ -31,7 +33,6 @@ SEND_EVENT_RESPONSE=$(
     "$breadcrumbs"
 )
 rm "$log_file"
-expected_filename='sentry-envelope-f73e4da437c42a1d28b86a81ebcff35d'
 test "$SEND_EVENT_RESPONSE" == "Test Sending $expected_filename"
 ENVELOPE_CONTENTS=$(cat "/tmp/$expected_filename")
 test "$ENVELOPE_CONTENTS" == "$(cat _unit-test/snapshots/$expected_filename)"
@@ -61,7 +62,7 @@ export dc=':'
 echo "Test Logs" >"$log_file"
 CLEANUP_RESPONSE=$(cleanup ERROR) # the linenumber of this line must match just below
 rm "$log_file"
-test "$CLEANUP_RESPONSE" == 'Error in _unit-test/error-handling-test.sh:62.
+test "$CLEANUP_RESPONSE" == 'Error in _unit-test/error-handling-test.sh:63.
 '\''local cmd="${BASH_COMMAND}"'\'' exited with status 0
 
 Cleaning up...'
@@ -75,10 +76,23 @@ export MINIMIZE_DOWNTIME=1
 echo "Test Logs" >"$log_file"
 CLEANUP_RESPONSE=$(cleanup ERROR) # the linenumber of this line must match just below
 rm "$log_file"
-test "$CLEANUP_RESPONSE" == 'Error in _unit-test/error-handling-test.sh:76.
+test "$CLEANUP_RESPONSE" == 'Error in _unit-test/error-handling-test.sh:77.
 '\''local cmd="${BASH_COMMAND}"'\'' exited with status 0
 
 *NOT* cleaning up, to clean your environment run "docker compose stop".'
+echo "Pass."
+
+##########################
+
+echo "Testing breadcrumb truncation limit"
+export SENTRY_MAX_BREADCRUMB_LINES=2
+echo "first" >"$log_file"
+echo "second" >>"$log_file"
+echo "Error Msg" >>"$log_file"
+CAPPED_BREADCRUMBS=$(collect_breadcrumbs)
+rm "$log_file"
+unset SENTRY_MAX_BREADCRUMB_LINES
+test "$CAPPED_BREADCRUMBS" == '[{"message":"second","category":"log","level":"info"}]'
 echo "Pass."
 
 ##########################

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -19,6 +19,8 @@ generate_breadcrumb_json() {
   $jq -R -c '{"message": ., "category": "log", "level": "info"}'
 }
 
+# Create the breadcrumb payload now before stacktrace is printed
+# https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
 collect_breadcrumbs() {
   local line_limit="${SENTRY_MAX_BREADCRUMB_LINES:-$DEFAULT_BREADCRUMB_LINE_LIMIT}"
   if ! [[ "$line_limit" =~ ^[1-9][0-9]*$ ]]; then
@@ -187,9 +189,6 @@ cleanup() {
     set +o xtrace
     # Save the error message that comes from the last line of the log file
     error_msg=$(tail -n 1 "$log_file")
-    # Create the breadcrumb payload now before stacktrace is printed
-    # https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
-    # Use sed to remove the last line, that is reported through the error message
     breadcrumbs=$(collect_breadcrumbs)
     printf -v err '%s' "Error in ${BASH_SOURCE[1]}:${BASH_LINENO[0]}."
     printf -v cmd_exit '%s' "'$cmd' exited with status $retcode"

--- a/install/error-handling.sh
+++ b/install/error-handling.sh
@@ -8,6 +8,7 @@ $dbuild -t sentry-self-hosted-jq-local --platform="$DOCKER_PLATFORM" jq
 
 jq="$CONTAINER_ENGINE run --rm -i sentry-self-hosted-jq-local"
 sentry_cli="$CONTAINER_ENGINE run --rm -v /tmp:/work -e SENTRY_DSN=$SENTRY_DSN getsentry/sentry-cli"
+DEFAULT_BREADCRUMB_LINE_LIMIT=200
 
 send_envelope() {
   # Send envelope
@@ -15,7 +16,15 @@ send_envelope() {
 }
 
 generate_breadcrumb_json() {
-  cat $log_file | $jq -R -c 'split("\n") | {"message": (.[0]//""), "category": "log", "level": "info"}'
+  $jq -R -c '{"message": ., "category": "log", "level": "info"}'
+}
+
+collect_breadcrumbs() {
+  local line_limit="${SENTRY_MAX_BREADCRUMB_LINES:-$DEFAULT_BREADCRUMB_LINE_LIMIT}"
+  if ! [[ "$line_limit" =~ ^[1-9][0-9]*$ ]]; then
+    line_limit=$DEFAULT_BREADCRUMB_LINE_LIMIT
+  fi
+  tail -n "$line_limit" "$log_file" | sed '$d' | generate_breadcrumb_json | $jq -s -c '.'
 }
 
 send_event() {
@@ -73,11 +82,10 @@ send_event() {
   # spam in the system). It was also futzy to figure out how to get the
   # traceback in there properly. Meh.
   event_body=$(
-    $jq -n -c --arg level error \
-      --argjson exception "{\"values\":[$exception]}" \
-      --argjson breadcrumbs "{\"values\": $breadcrumbs}" \
-      --argjson fingerprint "[\"$fingerprint_value\"]" \
-      '$ARGS.named'
+    printf '%s\n%s\n' "$exception" "$breadcrumbs" |
+      $jq -s -c --arg level error \
+        --arg fingerprint "$fingerprint_value" \
+        '{"level": $level, "exception": {"values": [.[0]]}, "breadcrumbs": {"values": .[1]}, "fingerprint": [$fingerprint]}'
   )
   echo "$event_body" >>$envelope_file_path
   # Add attachment to the event
@@ -182,7 +190,7 @@ cleanup() {
     # Create the breadcrumb payload now before stacktrace is printed
     # https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
     # Use sed to remove the last line, that is reported through the error message
-    breadcrumbs=$(generate_breadcrumb_json | sed '$d' | $jq -s -c)
+    breadcrumbs=$(collect_breadcrumbs)
     printf -v err '%s' "Error in ${BASH_SOURCE[1]}:${BASH_LINENO[0]}."
     printf -v cmd_exit '%s' "'$cmd' exited with status $retcode"
     printf '%s\n%s\n' "$err" "$cmd_exit"


### PR DESCRIPTION
Previously some users reported that they are facing errors of 'docker argument list too long', it's annoying and hard to debug for us maintainers. This should prevent that.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
