### PR TITLE
chore(sentry-cli): Upgrade to 3.4.3

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -217,7 +217,7 @@ runs:
 
     - name: Setup Sentry CLI
       shell: bash
-      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.4.1" bash
+      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.4.3" bash
 
     - name: Install Nodejs dependencies
       shell: bash


### PR DESCRIPTION
Upgrade sentry-cli to [3.4.3](https://github.com/getsentry/sentry-cli/releases/tag/3.4.3), which includes security fixes.