### PR TITLE
docs(auth): Add email backend recommendation to config example

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -7,6 +7,11 @@
 # Mail Server #
 ###############
 
+# We strongly recommend configuring an email backend. Without one, users can't
+# verify their primary email or add secondary/backup emails. Email verification
+# protects accounts from unauthorized access — if you skip this, there's no way
+# to confirm a user owns the email address on their account.
+
 # mail.backend: 'smtp'  # Use dummy if you want to disable email entirely
 mail.host: 'smtp'
 # mail.port: 25


### PR DESCRIPTION
- Adds a comment to `config.example.yml` recommending email backend configuration
- Secondary email verification will be enforced, so without an email backend users cannot add secondary/backup emails or verify their primary email

## Context
We will make secondary email verification required (emails must be verified before they're added to a user) [in this pr](https://github.com/getsentry/sentry/pull/116748). Self-hosted instances that don't have an email backend configured will silently lose the ability to add secondary emails since verification links can't be sent. This comment makes that dependency explicit so admins know to set up email if they want full account management functionality.

Will add documentation [here](https://develop.sentry.dev/self-hosted/configuration/email/) as well