### PR TITLE
ref(taskbroker): Migrate to new kafka_clusters/kafka_topics config format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -776,20 +776,20 @@ services:
     <<: [*restart_policy, *pull_policy]
     image: "$TASKBROKER_IMAGE"
     environment:
-      # Multi-topic/cluster config via env vars: nested keys use "__", and
-      # figment lowercases each segment, so topic/cluster names can only use
-      # underscores (not hyphens) when set this way.
+      # The cluster address (and, in the external-kafka variant, its auth) is
+      # supplied via env vars. Topics live in the mounted config file
+      # (./taskbroker/config.yml) so they can use hyphenated names — env-var
+      # config keys can't contain hyphens.
       TASKBROKER_KAFKA_CLUSTERS__DEFAULT__ADDRESS: "kafka:9092"
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER__CLUSTER: "default"
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER__CONSUMER_GROUP: "taskworker"
-      TASKBROKER_KAFKA_DEADLETTER_TOPIC: "taskworker_dlq"
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__CLUSTER: "default"
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__CONSUMER_GROUP: "taskworker"
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__PRODUCE_ONLY: "true"
       TASKBROKER_DB_PATH: "/opt/sqlite/taskbroker-activations.sqlite"
       TASKBROKER_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
+    command: /opt/taskbroker -c /etc/taskbroker/config.yml
     volumes:
       - sentry-taskbroker:/opt/sqlite
+      - type: bind
+        read_only: true
+        source: ./taskbroker
+        target: /etc/taskbroker
     depends_on:
       kafka:
         <<: *depends_on-healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -776,8 +776,16 @@ services:
     <<: [*restart_policy, *pull_policy]
     image: "$TASKBROKER_IMAGE"
     environment:
-      TASKBROKER_KAFKA_CLUSTER: "kafka:9092"
-      TASKBROKER_KAFKA_DEADLETTER_CLUSTER: "kafka:9092"
+      # Multi-topic/cluster config via env vars: nested keys use "__", and
+      # figment lowercases each segment, so topic/cluster names can only use
+      # underscores (not hyphens) when set this way.
+      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__ADDRESS: "kafka:9092"
+      TASKBROKER_KAFKA_TOPICS__TASKWORKER__CLUSTER: "default"
+      TASKBROKER_KAFKA_TOPICS__TASKWORKER__CONSUMER_GROUP: "taskworker"
+      TASKBROKER_KAFKA_DEADLETTER_TOPIC: "taskworker_dlq"
+      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__CLUSTER: "default"
+      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__CONSUMER_GROUP: "taskworker"
+      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__PRODUCE_ONLY: "true"
       TASKBROKER_DB_PATH: "/opt/sqlite/taskbroker-activations.sqlite"
       TASKBROKER_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
     volumes:

--- a/optional-modifications/patches/external-kafka/docker-compose.yml.patch
+++ b/optional-modifications/patches/external-kafka/docker-compose.yml.patch
@@ -104,14 +104,19 @@
        redis:
          <<: *depends_on-healthy
        web:
-@@ -778,8 +752,16 @@
+@@ -776,11 +750,18 @@
+     <<: [*restart_policy, *pull_policy]
+     image: "$TASKBROKER_IMAGE"
      environment:
-       # Multi-topic/cluster config via env vars: nested keys use "__", and
-       # figment lowercases each segment, so topic/cluster names can only use
--      # underscores (not hyphens) when set this way.
+-      # The cluster address (and, in the external-kafka variant, its auth) is
+-      # supplied via env vars. Topics live in the mounted config file
+-      # (./taskbroker/config.yml) so they can use hyphenated names — env-var
+-      # config keys can't contain hyphens.
 -      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__ADDRESS: "kafka:9092"
-+      # underscores (not hyphens) when set this way. The consumed topic and the
-+      # deadletter topic share one cluster (and its auth).
++      # The cluster address and its auth are supplied via env vars (this
++      # external-kafka variant points them at the user's brokers). Topics live
++      # in the mounted config file (./taskbroker/config.yml) so they can use
++      # hyphenated names — env-var config keys can't contain hyphens.
 +      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__ADDRESS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}
 +      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SECURITY_PROTOCOL: ${KAFKA_SECURITY_PROTOCOL:-PLAINTEXT}
 +      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SSL_CA_LOCATION: ${KAFKA_SSL_CA_LOCATION:-}
@@ -120,20 +125,20 @@
 +      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SASL_MECHANISM: ${KAFKA_SASL_MECHANISM:-}
 +      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SASL_USERNAME: ${KAFKA_SASL_USERNAME:-}
 +      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SASL_PASSWORD: ${KAFKA_SASL_PASSWORD:-}
-       TASKBROKER_KAFKA_TOPICS__TASKWORKER__CLUSTER: "default"
-       TASKBROKER_KAFKA_TOPICS__TASKWORKER__CONSUMER_GROUP: "taskworker"
-       TASKBROKER_KAFKA_DEADLETTER_TOPIC: "taskworker_dlq"
-@@ -790,9 +772,6 @@
+       TASKBROKER_DB_PATH: "/opt/sqlite/taskbroker-activations.sqlite"
        TASKBROKER_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
-     volumes:
-       - sentry-taskbroker:/opt/sqlite
+     command: /opt/taskbroker -c /etc/taskbroker/config.yml
+@@ -790,9 +771,6 @@
+         read_only: true
+         source: ./taskbroker
+         target: /etc/taskbroker
 -    depends_on:
 -      kafka:
 -        <<: *depends_on-healthy
    taskscheduler:
      <<: *sentry_defaults
      command: run taskworker-scheduler
-@@ -828,14 +807,23 @@
+@@ -828,14 +806,23 @@
      <<: [*restart_policy, *pull_policy]
      image: "$VROOM_IMAGE"
      environment:
@@ -159,7 +164,7 @@
      healthcheck:
        <<: *healthcheck_defaults
        test:
-@@ -844,9 +832,6 @@
+@@ -844,9 +831,6 @@
          - "-c"
          # Courtesy of https://unix.stackexchange.com/a/234089/108960
          - 'exec 3<>/dev/tcp/127.0.0.1/8085 && echo -e "GET /health HTTP/1.1\r\nhost: 127.0.0.1\r\n\r\n" >&3 && grep OK -s -m 1 <&3'
@@ -169,7 +174,7 @@
      profiles:
        - feature-complete
    uptime-checker:
-@@ -854,7 +839,14 @@
+@@ -854,7 +838,14 @@
      image: "$UPTIME_CHECKER_IMAGE"
      command: run
      environment:
@@ -185,7 +190,7 @@
        UPTIME_CHECKER_REDIS_HOST: redis://redis:6379
        # Set to `true` will allow uptime checks against private IP addresses
        UPTIME_CHECKER_ALLOW_INTERNAL_IPS: "false"
-@@ -866,8 +858,6 @@
+@@ -866,8 +857,6 @@
        #UPTIME_CHECKER_HTTP_CHECKER_DNS_NAMESERVERS: "8.8.8.8,8.8.4.4"
        UPTIME_CHECKER_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
      depends_on:
@@ -194,7 +199,7 @@
        redis:
          <<: *depends_on-healthy
      profiles:
-@@ -881,8 +871,6 @@
+@@ -881,8 +870,6 @@
      external: true
    sentry-redis:
      external: true

--- a/optional-modifications/patches/external-kafka/docker-compose.yml.patch
+++ b/optional-modifications/patches/external-kafka/docker-compose.yml.patch
@@ -1,6 +1,6 @@
---- docker-compose.yml	2026-03-15 21:35:31.736074540 +0700
-+++ docker-compose.external-kafka.yml	2026-03-15 21:40:44.675091837 +0700
-@@ -34,8 +34,6 @@
+--- docker-compose.yml
++++ docker-compose.external-kafka.yml
+@@ -54,8 +54,6 @@
    depends_on:
      redis:
        <<: *depends_on-healthy
@@ -9,9 +9,9 @@
      pgbouncer:
        <<: *depends_on-healthy
      memcached:
-@@ -71,6 +69,14 @@
-     SENTRY_MAX_EXTERNAL_SOURCEMAP_SIZE:
+@@ -92,6 +90,14 @@
      SENTRY_SYSTEM_SECRET_KEY:
+     LAUNCHPAD_RPC_SHARED_SECRET:
      SENTRY_STATSD_ADDR: "${STATSD_ADDR:-}"
 +    KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}
 +    KAFKA_SECURITY_PROTOCOL: ${KAFKA_SECURITY_PROTOCOL:-PLAINTEXT}
@@ -24,7 +24,7 @@
    volumes:
      - "sentry-data:/data"
      - "./sentry:/etc/sentry"
-@@ -81,15 +87,20 @@
+@@ -102,15 +108,20 @@
    depends_on:
      clickhouse:
        <<: *depends_on-healthy
@@ -48,7 +48,7 @@
      REDIS_HOST: redis
      UWSGI_MAX_REQUESTS: "10000"
      UWSGI_DISABLE_LOGGING: "true"
-@@ -171,43 +182,7 @@
+@@ -192,43 +203,7 @@
        ADMIN_USERS: postgres,sentry
        MAX_CLIENT_CONN: 10000
  
@@ -93,7 +93,7 @@
    clickhouse:
      <<: [*restart_policy, *pull_policy]
      image: clickhouse-self-hosted-local
-@@ -721,9 +696,8 @@
+@@ -765,9 +740,8 @@
          read_only: true
          source: ./geoip
          target: /geoip
@@ -104,29 +104,26 @@
        redis:
          <<: *depends_on-healthy
        web:
-@@ -735,15 +709,26 @@
-     <<: *restart_policy
-     image: "$TASKBROKER_IMAGE"
+@@ -778,8 +752,16 @@
      environment:
--      TASKBROKER_KAFKA_CLUSTER: "kafka:9092"
--      TASKBROKER_KAFKA_DEADLETTER_CLUSTER: "kafka:9092"
-+      TASKBROKER_KAFKA_CLUSTER: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}
-+      TASKBROKER_KAFKA_SECURITY_PROTOCOL: ${KAFKA_SECURITY_PROTOCOL:-PLAINTEXT}
-+      TASKBROKER_KAFKA_SSL_CA_LOCATION: ${KAFKA_SSL_CA_LOCATION:-}
-+      TASKBROKER_KAFKA_SSL_CERTIFICATE_LOCATION: ${KAFKA_SSL_CERTIFICATE_LOCATION:-}
-+      TASKBROKER_KAFKA_SSL_KEY_LOCATION: ${KAFKA_SSL_KEY_LOCATION:-}
-+      TASKBROKER_KAFKA_SASL_MECHANISM: ${KAFKA_SASL_MECHANISM:-}
-+      TASKBROKER_KAFKA_SASL_USERNAME: ${KAFKA_SASL_USERNAME:-}
-+      TASKBROKER_KAFKA_SASL_PASSWORD: ${KAFKA_SASL_PASSWORD:-}
-+      TASKBROKER_KAFKA_DEADLETTER_CLUSTER: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}
-+      TASKBROKER_KAFKA_DEADLETTER_SECURITY_PROTOCOL: ${KAFKA_SECURITY_PROTOCOL:-PLAINTEXT}
-+      TASKBROKER_KAFKA_DEADLETTER_SSL_CA_LOCATION: ${KAFKA_SSL_CA_LOCATION:-}
-+      TASKBROKER_KAFKA_DEADLETTER_SSL_CERTIFICATE_LOCATION: ${KAFKA_SSL_CERTIFICATE_LOCATION:-}
-+      TASKBROKER_KAFKA_DEADLETTER_SSL_KEY_LOCATION: ${KAFKA_SSL_KEY_LOCATION:-}
-+      TASKBROKER_KAFKA_DEADLETTER_SASL_MECHANISM: ${KAFKA_SASL_MECHANISM:-}
-+      TASKBROKER_KAFKA_DEADLETTER_SASL_USERNAME: ${KAFKA_SASL_USERNAME:-}
-+      TASKBROKER_KAFKA_DEADLETTER_SASL_PASSWORD: ${KAFKA_SASL_PASSWORD:-}
-       TASKBROKER_DB_PATH: "/opt/sqlite/taskbroker-activations.sqlite"
+       # Multi-topic/cluster config via env vars: nested keys use "__", and
+       # figment lowercases each segment, so topic/cluster names can only use
+-      # underscores (not hyphens) when set this way.
+-      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__ADDRESS: "kafka:9092"
++      # underscores (not hyphens) when set this way. The consumed topic and the
++      # deadletter topic share one cluster (and its auth).
++      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__ADDRESS: ${KAFKA_BOOTSTRAP_SERVERS:-kafka:9092}
++      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SECURITY_PROTOCOL: ${KAFKA_SECURITY_PROTOCOL:-PLAINTEXT}
++      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SSL_CA_LOCATION: ${KAFKA_SSL_CA_LOCATION:-}
++      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SSL_CERTIFICATE_LOCATION: ${KAFKA_SSL_CERTIFICATE_LOCATION:-}
++      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SSL_KEY_LOCATION: ${KAFKA_SSL_KEY_LOCATION:-}
++      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SASL_MECHANISM: ${KAFKA_SASL_MECHANISM:-}
++      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SASL_USERNAME: ${KAFKA_SASL_USERNAME:-}
++      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__SASL_PASSWORD: ${KAFKA_SASL_PASSWORD:-}
+       TASKBROKER_KAFKA_TOPICS__TASKWORKER__CLUSTER: "default"
+       TASKBROKER_KAFKA_TOPICS__TASKWORKER__CONSUMER_GROUP: "taskworker"
+       TASKBROKER_KAFKA_DEADLETTER_TOPIC: "taskworker_dlq"
+@@ -790,9 +772,6 @@
        TASKBROKER_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
      volumes:
        - sentry-taskbroker:/opt/sqlite
@@ -136,8 +133,8 @@
    taskscheduler:
      <<: *sentry_defaults
      command: run taskworker-scheduler
-@@ -756,14 +741,23 @@
-     <<: *restart_policy
+@@ -828,14 +807,23 @@
+     <<: [*restart_policy, *pull_policy]
      image: "$VROOM_IMAGE"
      environment:
 -      SENTRY_KAFKA_BROKERS_PROFILING: "kafka:9092"
@@ -162,7 +159,7 @@
      healthcheck:
        <<: *healthcheck_defaults
        test:
-@@ -772,9 +766,6 @@
+@@ -844,9 +832,6 @@
          - "-c"
          # Courtesy of https://unix.stackexchange.com/a/234089/108960
          - 'exec 3<>/dev/tcp/127.0.0.1/8085 && echo -e "GET /health HTTP/1.1\r\nhost: 127.0.0.1\r\n\r\n" >&3 && grep OK -s -m 1 <&3'
@@ -172,7 +169,7 @@
      profiles:
        - feature-complete
    uptime-checker:
-@@ -782,7 +773,14 @@
+@@ -854,7 +839,14 @@
      image: "$UPTIME_CHECKER_IMAGE"
      command: run
      environment:
@@ -188,7 +185,7 @@
        UPTIME_CHECKER_REDIS_HOST: redis://redis:6379
        # Set to `true` will allow uptime checks against private IP addresses
        UPTIME_CHECKER_ALLOW_INTERNAL_IPS: "false"
-@@ -794,8 +792,6 @@
+@@ -866,8 +858,6 @@
        #UPTIME_CHECKER_HTTP_CHECKER_DNS_NAMESERVERS: "8.8.8.8,8.8.4.4"
        UPTIME_CHECKER_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
      depends_on:
@@ -197,7 +194,7 @@
        redis:
          <<: *depends_on-healthy
      profiles:
-@@ -809,8 +805,6 @@
+@@ -881,8 +871,6 @@
      external: true
    sentry-redis:
      external: true

--- a/optional-modifications/patches/external-kafka/docker-compose.yml.patch
+++ b/optional-modifications/patches/external-kafka/docker-compose.yml.patch
@@ -1,5 +1,5 @@
---- docker-compose.yml
-+++ docker-compose.external-kafka.yml
+--- docker-compose.yml	2026-03-15 21:35:31.736074540 +0700
++++ docker-compose.external-kafka.yml	2026-03-15 21:40:44.675091837 +0700
 @@ -54,8 +54,6 @@
    depends_on:
      redis:

--- a/taskbroker/config.yml
+++ b/taskbroker/config.yml
@@ -1,0 +1,16 @@
+# Taskbroker Kafka topology.
+#
+# Topics are declared here (rather than via TASKBROKER_KAFKA_TOPICS__* env vars)
+# so they can use hyphenated names — env-var config keys can't contain hyphens.
+# The cluster address and auth are supplied via TASKBROKER_KAFKA_CLUSTERS__*
+# env vars in docker-compose.yml (the external-kafka patch overrides them).
+kafka_deadletter_topic: taskworker-dlq
+
+kafka_topics:
+  taskworker:
+    cluster: default
+    consumer_group: taskworker
+  taskworker-dlq:
+    cluster: default
+    consumer_group: taskworker
+    produce_only: true

--- a/taskbroker/config.yml
+++ b/taskbroker/config.yml
@@ -1,9 +1,4 @@
-# Taskbroker Kafka topology.
-#
-# Topics are declared here (rather than via TASKBROKER_KAFKA_TOPICS__* env vars)
-# so they can use hyphenated names — env-var config keys can't contain hyphens.
-# The cluster address and auth are supplied via TASKBROKER_KAFKA_CLUSTERS__*
-# env vars in docker-compose.yml (the external-kafka patch overrides them).
+# See https://github.com/getsentry/taskbroker/pull/667 for the config format.
 kafka_deadletter_topic: taskworker-dlq
 
 kafka_topics:


### PR DESCRIPTION
See https://github.com/getsentry/taskbroker/pull/667 for details.

The short version of this is, we are making some changes to kafka configuration that affect every user. The change is already out in the latest version of self-hosted and users should already get deprecation warnings as per https://github.com/getsentry/taskbroker/pull/663

The config change is desired so we can configure multiple kafka topics and clusters for a single taskbroker container. All of this can be configured in envvars, too, but at this point it'll be more readable to move to yaml (which taskbroker supported all along)

ALso, `taskworker-dlq` can't be defined as a topic via envvars (hyphens aren't permitted there), which is the main reason this moves the topic config into a mounted yaml file.