### PR TITLE
Adjust ClickHouse configuration to disable query_views_log

### DIFF
--- a/clickhouse/config.xml
+++ b/clickhouse/config.xml
@@ -7,6 +7,7 @@
     </logger>
     <query_thread_log remove="remove"/>
     <query_log remove="remove"/>
+    <query_views_log remove="remove"/>
     <text_log remove="remove"/>
     <trace_log remove="remove"/>
     <metric_log remove="remove"/>

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ source install/check-minimum-requirements.sh
 # Upgrading clickhouse needs to come first before turning things off, since we need the old clickhouse image
 # in order to determine whether or not the clickhouse version needs to be upgraded.
 source install/upgrade-clickhouse.sh
+source install/cleanup-clickhouse.sh
 source install/update-docker-images.sh
 source install/turn-things-off.sh
 source install/create-docker-volumes.sh

--- a/install/cleanup-clickhouse.sh
+++ b/install/cleanup-clickhouse.sh
@@ -1,0 +1,39 @@
+echo "${_group}Cleaning up ClickHouse query log tables ..."
+
+if [ "$CONTAINER_ENGINE" = "podman" ]; then
+  ps_command="$dc ps"
+else
+  ps_command="$dc ps -a"
+fi
+
+drop_clickhouse_system_table_if_exists() {
+  local table="$1"
+  local table_exists
+
+  table_exists=$($dc exec clickhouse clickhouse-client -q "SELECT count() FROM system.tables WHERE database = 'system' AND name = '$table'")
+
+  if [[ "$table_exists" == "1" ]]; then
+    echo "Dropping system.$table ..."
+    $dc exec clickhouse clickhouse-client -q "DROP TABLE system.$table"
+  else
+    echo "system.$table does not exist, skipping."
+  fi
+}
+
+truncate_clickhouse_query_log_tables() {
+  echo "Truncating system.query_log and system.query_views_log ..."
+  $dc exec clickhouse clickhouse-client --multiquery -q "
+SYSTEM FLUSH LOGS;
+TRUNCATE TABLE IF EXISTS system.query_log;
+TRUNCATE TABLE IF EXISTS system.query_views_log;
+"
+}
+
+if $ps_command | grep -q clickhouse; then
+  start_service_and_wait_ready clickhouse
+  drop_clickhouse_system_table_if_exists query_log_0
+  drop_clickhouse_system_table_if_exists query_views_log_0
+  truncate_clickhouse_query_log_tables
+fi
+
+echo "${_endgroup}"


### PR DESCRIPTION
<img width="2041" height="830" alt="image" src="https://github.com/user-attachments/assets/86a306ee-ed8e-4bda-abd4-ca422c1b11fc" />

As you can see in the screenshot above clickhouse doesn't cleanup its views_log tables automatically, see https://clickhouse.com/docs/operations/system-tables/query_views_log

> ClickHouse does not delete data from the table automatically. 

I don't think this is necessary in a "normal" self-hosted environment unless someone needs to debug clickhouse.

This of course does not truncate the existing tables, that maybe needs to be added to the install script.
@aldy505 what do you think?

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
