### PR TITLE
Increase proxy_read_timeout to 90s

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -62,7 +62,7 @@ http {
 	proxy_set_header X-Forwarded-For $remote_addr;
 	proxy_set_header X-Forwarded-Proto $scheme;
 	proxy_set_header X-Request-Id $request_id;
-	proxy_read_timeout 30s;
+	proxy_read_timeout 90s;
 	proxy_send_timeout 5s;
 
 	upstream relay {

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -305,9 +305,9 @@ SENTRY_WEB_OPTIONS = {
     # The `harakiri` option terminates requests that take longer than the
     # defined amount of time (in seconds) which can help avoid stuck workers
     # caused by GIL issues or deadlocks.
-    # Ensure nginx `proxy_read_timeout` configuration (default: 30)
+    # Ensure nginx `proxy_read_timeout` configuration (default: 90)
     # on your `nginx.conf` file to be at least 5 seconds longer than this.
-    # "harakiri": 25,
+    # "harakiri": 85,
     # Some stuff so uwsgi will cycle workers sensibly
     "max-requests": 100000,
     "max-requests-delta": 500,


### PR DESCRIPTION
On a large self-hosted instance, 30 seconds is too low for querying, also sentry keeps on doing the work (whatever it is) and `nginx` just drops the connection.

It's better to match this to sentry timeouts, this should also consider whether this is ok for slow API requests or not, as current change affects both.

Maybe we should separate these two? I'm going to draft this until I think about this more.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
