### PR TITLE
Reuse integration test login sessions

### DIFF
--- a/_integration-test/test_01_basics.py
+++ b/_integration-test/test_01_basics.py
@@ -69,8 +69,8 @@ def get_organization_token(client: httpx.Client, csrf_token: str, name: str) -> 
     token = json.loads(response.text)["token"]
     return token
 
-@pytest.fixture()
-def client_login():
+@pytest.fixture(scope="session")
+def authenticated_session():
     client = httpx.Client()
     response = client.get(SENTRY_TEST_HOST, follow_redirects=True)
     parser = BeautifulSoup(response.text, "html.parser")
@@ -87,7 +87,23 @@ def client_login():
         headers={"Referer": f"{SENTRY_TEST_HOST}/auth/login/sentry/"},
     )
     assert login_response.status_code == 200
+    parser = BeautifulSoup(login_response.text, "html.parser")
+    script_tag = parser.find(
+        "script", string=lambda x: x and "window.__initialData" in x
+    )
+    assert script_tag is not None
+    json_data = json.loads(script_tag.text.split("=", 1)[1].strip().rstrip(";"))
+    assert json_data["isAuthenticated"] is True
+    yield (httpx.Cookies(client.cookies), login_response)
+    client.close()
+
+
+@pytest.fixture()
+def client_login(authenticated_session):
+    cookies, login_response = authenticated_session
+    client = httpx.Client(cookies=httpx.Cookies(cookies))
     yield (client, login_response)
+    client.close()
 
 def test_initial_redirect():
     initial_auth_redirect = httpx.get(SENTRY_TEST_HOST, follow_redirects=True)

--- a/action.yaml
+++ b/action.yaml
@@ -175,19 +175,6 @@ runs:
 
         ./install.sh --no-report-self-hosted-issues --skip-commit-check
 
-        cat <<'EOT' >> sentry/sentry.conf.py
-        from sentry.ratelimits.redis import RedisRateLimiter
-
-        _original_is_limited = RedisRateLimiter.is_limited
-
-        def _self_hosted_integration_is_limited(self, key, limit, project=None, window=None):
-            if key.startswith("auth:login:username:"):
-                return False
-            return _original_is_limited(self, key, limit, project=project, window=window)
-
-        RedisRateLimiter.is_limited = _self_hosted_integration_is_limited
-        EOT
-
     - name: Save Sentry Volume Cache
       if: steps.restore_cache_sentry.outputs.cache-hit != 'true' && inputs.no_restore_volume_cache != 'true'
       uses: BYK/docker-volume-cache-action/save@0efa5cf5178c9906cb46ed8d1a357df8fd6b1a06

--- a/action.yaml
+++ b/action.yaml
@@ -175,6 +175,19 @@ runs:
 
         ./install.sh --no-report-self-hosted-issues --skip-commit-check
 
+        cat <<'EOT' >> sentry/sentry.conf.py
+        from sentry.ratelimits.redis import RedisRateLimiter
+
+        _original_is_limited = RedisRateLimiter.is_limited
+
+        def _self_hosted_integration_is_limited(self, key, limit, project=None, window=None):
+            if key.startswith("auth:login:username:"):
+                return False
+            return _original_is_limited(self, key, limit, project=project, window=window)
+
+        RedisRateLimiter.is_limited = _self_hosted_integration_is_limited
+        EOT
+
     - name: Save Sentry Volume Cache
       if: steps.restore_cache_sentry.outputs.cache-hit != 'true' && inputs.no_restore_volume_cache != 'true'
       uses: BYK/docker-volume-cache-action/save@0efa5cf5178c9906cb46ed8d1a357df8fd6b1a06


### PR DESCRIPTION
After https://github.com/getsentry/self-hosted/pull/4312 has been merged, it passed sentry’s login limit at 5 / 60 seconds and this gets flaky like

https://github.com/getsentry/self-hosted/actions/runs/27093754802/job/79962010465?pr=4367

~~This PR disables sentry login rate-limit for integration tests.~~

Disabling login rate-limit failed, as it was trying to do that before sentry is up.

I changed the PR to reuse login sessions in integration tests, so integration tests hit sentry login less.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
