### PR TITLE
feat(ci): run tests every 6 hours on the weekdays

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,9 @@ on:
       - "release/**"
   pull_request:
   schedule:
-    - cron: "0 0,12 * * *"
+    # Timezone is UTC by default
+    - cron: "0 0,6,12,18 * * 1-5" # weekdays
+    - cron: "0 0,12 * * 6,0" # weekends
 
 concurrency:
   group: ${{ github.ref_name || github.sha }}


### PR DESCRIPTION
Currently we have the tests running every 12 hours everyday, it's hard to keep track of issues that happen during the weekdays. Therefore, I separate the schedule to run on the weekdays for every 6 hours and on the weekends every 12 hours.
