### PR TITLE
chore(ci): declare 'timeout-minutes' on tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
   unit-test:
     if: github.repository_owner == 'getsentry'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
@@ -42,6 +43,7 @@ jobs:
   integration-test:
     if: github.repository_owner == 'getsentry'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +79,7 @@ jobs:
   integration-test-errors-only:
     if: github.repository_owner == 'getsentry'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Avoiding the test to run for 6 hours and wasting resource & money for Sentry's account
