### PR TITLE
Fix: Disable in-pod placement for podman-compose by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,11 @@ x-snuba-defaults: &snuba_defaults
     # If you have statsd server, you can utilize that to monitor self-hosted Snuba containers.
     # To start, state these environment variables below on your `.env.` file and adjust the options as needed.
     SNUBA_STATSD_ADDR: "${STATSD_ADDR:-}"
+
+# Prevent podman from placing the compose stack and ad-hoc containers into pods
+x-podman:
+  in_pod: false
+
 services:
   smtp:
     <<: *restart_policy

--- a/install/dc-detect-version.sh
+++ b/install/dc-detect-version.sh
@@ -51,10 +51,7 @@ proxy_args="--build-arg HTTP_PROXY=${HTTP_PROXY:-} --build-arg HTTPS_PROXY=${HTT
 exec_proxy_args="-e HTTP_PROXY=${HTTP_PROXY:-} -e HTTPS_PROXY=${HTTPS_PROXY:-} -e NO_PROXY=${NO_PROXY:-} -e http_proxy=${http_proxy:-} -e https_proxy=${https_proxy:-} -e no_proxy=${no_proxy:-}"
 if [[ "$CONTAINER_ENGINE" == "podman" ]]; then
   proxy_args_dc="--podman-build-args HTTP_PROXY=${HTTP_PROXY:-},HTTPS_PROXY=${HTTPS_PROXY:-},NO_PROXY=${NO_PROXY:-},http_proxy=${http_proxy:-},https_proxy=${https_proxy:-},no_proxy=${no_proxy:-}"
-  # Disable pod creation as these are one-off commands and creating a pod
-  # prints its pod id to stdout which is messing with the output that we
-  # rely on various places such as configuration generation
-  dcr="$dc --profile=feature-complete --in-pod=false run --rm"
+  dcr="$dc --profile=feature-complete run --rm"
 else
   proxy_args_dc=$proxy_args
   dcr="$dc run --pull=never --rm"


### PR DESCRIPTION
Hi Sentry community 👋🏼 

When deploying self-hosted Sentry using rootless Podman and podman-compose instead of Docker/Docker compose, the containers may be placed inside a Pod.  
This causes issues because the ad-hoc container runs performed by the install/upgrade script will fail if the dependencies are placed inside Pods.

Either:
- The run command is rejected because the launched container is not in a Pod (see previously used work-around) and its dependencies are in a Pod.
- The run command is rejected because the launched container is in a different (newly created) Pod than its dependencies from the stack.

The default behavior of podman-compose has [changed from one stable version to another](https://github.com/containers/podman-compose/pull/964) where containers are now placed inside Pods by default.
This PR aims to solve this compatibility issue by defining not being in a Pod as the default for this compose stack.

### Background information

I'm currently deploying Self-Hosted Sentry on a RHEL VM with rootless podman and podman-compose being mandated by policy. I've gotten things running and I've even been able to make the deployment reproducible using Ansible.

Since Docker / Docker compose is not available to me, I am not able to verify whether Docker setups are un-touched by these changes. I am hoping somebody running Docker or the tests can verify that for me.

### Left-out changes

Since Podman runs rootless (which means all containers run inside some user namespace) and the machine has SELinux enabled, there were additional changes needed to make things run. These involve mainly file permissions and se_labels.
Please let me know If I should even contribute this as it appears to be a rather niche deployment environment.

There's also one issue where the ``pip install https://(....)`` in a Dockerfile fails because this file does not take custom CA certificates into account. I might feel like contributing some fix for this too at a later time.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
