### PR TITLE
Bump pgbouncer 1.25.2-p0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
     shm_size: 256m
   pgbouncer:
     <<: *restart_policy
-    image: "edoburu/pgbouncer:v1.24.1-p1"
+    image: "edoburu/pgbouncer:v1.25.2-p0"
     healthcheck:
       <<: *healthcheck_defaults
       # Using default user "postgres" from sentry/sentry.conf.example.py or value of POSTGRES_USER if provided


### PR DESCRIPTION
Fixes a couple of security issues, fixed in 1.25.2
https://github.com/pgbouncer/pgbouncer/releases/tag/pgbouncer_1_25_0
https://github.com/pgbouncer/pgbouncer/releases/tag/pgbouncer_1_25_1
https://github.com/pgbouncer/pgbouncer/releases/tag/pgbouncer_1_25_2

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
