### PR TITLE
feat(taskbroker): port profiles consumer to taskbroker raw mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -623,13 +623,6 @@ services:
       <<: *file_healthcheck_defaults
     profiles:
       - feature-complete
-  ingest-profiles:
-    <<: *sentry_defaults
-    command: run consumer ingest-profiles --consumer-group ingest-profiles --healthcheck-file-path /tmp/health.txt --max-poll-interval-ms ${SENTRY_KAFKA_MAX_POLL_INTERVAL_MS:-300000}
-    healthcheck:
-      <<: *file_healthcheck_defaults
-    profiles:
-      - feature-complete
   ingest-monitors:
     <<: *sentry_defaults
     command: run consumer ingest-monitors --consumer-group ingest-monitors --healthcheck-file-path /tmp/health.txt --max-poll-interval-ms ${SENTRY_KAFKA_MAX_POLL_INTERVAL_MS:-300000}

--- a/taskbroker/config.yml
+++ b/taskbroker/config.yml
@@ -1,5 +1,6 @@
 # See https://github.com/getsentry/taskbroker/pull/667 for the config format.
 kafka_deadletter_topic: taskworker-dlq
+kafka_retry_topic: taskworker
 
 kafka_topics:
   taskworker:
@@ -9,3 +10,11 @@ kafka_topics:
     cluster: default
     consumer_group: taskworker
     produce_only: true
+  profiles:
+    cluster: default
+    consumer_group: ingest-profiles-consumers-0
+    raw:
+      namespace: ingest.profiling.passthrough
+      application: sentry
+      taskname: sentry.profiles.task.process_profile_from_kafka
+      processing_deadline_duration: 60


### PR DESCRIPTION
Replaces the dedicated `ingest-profiles` consumer with taskbroker raw mode. This must be merged before the next sentry release, as the consumer code is already gone.

We're going to tear down the following consumers in sentry:

* profiles
* process-segments
* all subscriptions consumers
* ingest-replay-recordings

they're not all blocking the next release, though expect more PRs soon :)

ref STREAM-1248