### PR TITLE
Increase web healthcheck start_period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -552,6 +552,7 @@ services:
         hard: 4096
     healthcheck:
       <<: *healthcheck_defaults
+      start_period: 5m
       test:
         - "CMD"
         - "/bin/bash"


### PR DESCRIPTION
Increase `web` service `start_period` healthcheck to 5 minutes.

This is an attempt to fix integration test flaky integration test and failure after 2 minutes.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
