### PR TITLE
Upgrade docker images using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: docker
+  - package-ecosystem: docker-compose
     directory: "/"
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 0 # only security updates
     reviewers:
       - "@getsentry/dev-infra"
       - "@getsentry/security"


### PR DESCRIPTION
I got tired of upgrading `nginx` docker image.

At the time this line originally was written in https://github.com/getsentry/self-hosted/pull/2491, `dependabot` didn't support bumping docker images.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
