### PR TITLE
test: Add memcached integration test

### DIFF
--- a/_integration-test/test_01_basics.py
+++ b/_integration-test/test_01_basics.py
@@ -118,6 +118,47 @@ def test_asset_internal_rewrite():
     assert response.headers["Content-Type"] == "text/javascript"
 
 
+def test_memcached_django_cache():
+    script = """
+from uuid import uuid4
+
+from django.core.cache import caches
+
+cache = caches["default"]
+assert cache.__class__.__module__ == "sentry.cache.backends.reconnectingmemcache"
+assert cache.__class__.__name__ == "ReconnectingMemcache"
+
+key = f"self-hosted:memcached-integration-test:{uuid4()}"
+value = {"message": "works", "payload": b"x" * 800_000}
+
+try:
+    cache.set(key, value, timeout=60)
+    assert cache.get(key) == value
+    cache.delete(key)
+    assert cache.get(key) is None
+finally:
+    cache.delete(key)
+"""
+
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "--ansi",
+            "never",
+            "exec",
+            "-T",
+            "web",
+            "sentry",
+            "exec",
+        ],
+        input=script,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+
+
 def test_login(client_login):
     client, login_response = client_login
     parser = BeautifulSoup(login_response.text, "html.parser")


### PR DESCRIPTION
This PR adds an integration test which ensures, django is using memcached, writes a cache key (random 800 KB payload), reads it and asserts it's what it has written, deletes it and asserts it has been removed.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
