### PR TITLE
feat: Use valkey instead of redis

### DIFF
--- a/_integration-test/test_01_basics.py
+++ b/_integration-test/test_01_basics.py
@@ -159,6 +159,43 @@ finally:
     )
 
 
+def test_valkey_sentry_cache():
+    script = """
+from uuid import uuid4
+
+from sentry.cache import default_cache
+
+key = f"self-hosted:valkey-integration-test:{uuid4()}"
+value = {"message": "works", "items": [1, 2, 3]}
+
+try:
+    default_cache.set(key, value, timeout=60)
+    assert default_cache.get(key) == value
+    default_cache.delete(key)
+    assert default_cache.get(key) is None
+finally:
+    default_cache.delete(key)
+"""
+
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "--ansi",
+            "never",
+            "exec",
+            "-T",
+            "web",
+            "sentry",
+            "exec",
+        ],
+        input=script,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+
+
 def test_login(client_login):
     client, login_response = client_login
     parser = BeautifulSoup(login_response.text, "html.parser")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,10 +145,10 @@ services:
       test: echo stats | nc 127.0.0.1 11211
   redis:
     <<: *restart_policy
-    image: "redis:6.2.20-alpine"
+    image: "valkey/valkey:8.1.9-alpine"
     healthcheck:
       <<: *healthcheck_defaults
-      test: redis-cli ping | grep PONG
+      test: valkey-cli ping | grep PONG
     volumes:
       - "sentry-redis:/data"
       - type: bind
@@ -159,7 +159,7 @@ services:
       nofile:
         soft: 10032
         hard: 10032
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    command: ["valkey-server", "/usr/local/etc/redis/redis.conf"]
   postgres:
     <<: *restart_policy
     # Using the same postgres version as Sentry dev for consistency purposes


### PR DESCRIPTION
This has been essentially similar to https://github.com/getsentry/self-hosted/pull/3868 done by @aldy505 .

I tried testing if simple commands work after upgrading from current redis 6 users to valkey 8 in https://github.com/getsentry/self-hosted/pull/4437 and it got passed correctly as it was expected.

This PR also adds a simple test to see if redis / valkey is actually get used by sentry.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
