### PR TITLE
Fix snuba-api healthcheck bypassing proxy for local requests

### DIFF
--- a/snuba/api_healthcheck.py
+++ b/snuba/api_healthcheck.py
@@ -25,10 +25,17 @@ import urllib.request
 URL = os.environ.get("SNUBA_API_HEALTHCHECK_URL") or "http://127.0.0.1:1218/health"
 TIMEOUT = float(os.environ.get("SNUBA_API_HEALTHCHECK_TIMEOUT") or 2)
 
+# This is a local, in-container request. urllib's NO_PROXY matching doesn't
+# support CIDR ranges (e.g. 127.0.0.0/8), only exact hosts/domain suffixes,
+# so a NO_PROXY set up for other tools (curl, wget) can still leave this
+# request routed through HTTP(S)_PROXY. Force no proxy explicitly instead
+# of relying on NO_PROXY parsing.
+_NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
 
 def main() -> int:
     try:
-        body = urllib.request.urlopen(URL, timeout=TIMEOUT).read().decode()
+        body = _NO_PROXY_OPENER.open(URL, timeout=TIMEOUT).read().decode()
     except urllib.error.HTTPError as exc:
         print(f"snuba api returned HTTP {exc.code} from {URL}", file=sys.stderr)
         return 1


### PR DESCRIPTION
Fix snuba-api healthcheck bypassing proxy for local requests (urllib NO_PROXY doesn't support CIDR ranges)

<!-- Describe your PR here. -->

**Problem**

The snuba-api healthcheck (api_healthcheck.py) was failing in environments with an HTTP(S) proxy configured (HTTP_PROXY/HTTPS_PROXY). Squid logs confirmed the local request was being routed through the proxy and rejected:
TCP_DENIED/403 ... GET http://127.0.0.1:1218/health

**Root cause**

urllib.request does not support CIDR notation (127.0.0.0/8) in NO_PROXY — it only matches exact hostnames or domain suffixes. A NO_PROXY value that works for curl/wget can therefore still leave this local request routed through the configured proxy.

**Fix**

self-hosted/snuba/api_healthcheck.py now uses a dedicated urllib.request.build_opener(urllib.request.ProxyHandler({})) opener, explicitly forcing no proxy for this local request instead of relying on NO_PROXY parsing.

**Testing**

snuba-api healthcheck passes again after container rebuild, in an environment with HTTP_PROXY/HTTPS_PROXY configured.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

**Legal Boilerplate**

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
