### PR TITLE
ref: decrease Kafka log retention hours

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,7 +210,11 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
       KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: "1"
-      KAFKA_LOG_RETENTION_HOURS: "24"
+      # Lower the log retention to 1 hours to avoid filling up the disk,
+      # ONLY IF you have fast processing time and/or small data volumes.
+      # Otherwise, you can set it to a higher value if you have much slower
+      # processing time and/or larger data volumes.
+      KAFKA_LOG_RETENTION_HOURS: "3"
       KAFKA_MESSAGE_MAX_BYTES: "50000000" #50MB or bust
       KAFKA_MAX_REQUEST_SIZE: "50000000" #50MB on requests apparently too
       CONFLUENT_SUPPORT_METRICS_ENABLE: "false"


### PR DESCRIPTION
This is coming from a discussion from @jan-auer on Slack. He figured that it would be fine (or perhaps better) if the retention hours is set to 1 hour. I have a personal argument that 1 hour might not be enough for folks running in bigger volume and therefore slower processing time, therefore this 3 hours is a compromise.

To apply the change, the easiest way is to delete the Kafka volume, and let the `install.sh` script recreate it. But you can also do it manually using the kafka CLI:

```bash
for topic in $(docker compose exec kafka kafka-topics \
  --bootstrap-server kafka:9092 \
  --list); do
  docker compose exec kafka kafka-configs \
    --bootstrap-server kafka:9092 \
    --entity-type topics \
    --entity-name $topic \
    --alter \
    --add-config retention.ms=86400000
done
````
