### PR TITLE
Support proxy environment variables in jq/sentry/cron Docker builds

### DIFF
--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -5,10 +5,6 @@ ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG http_proxy
 ARG https_proxy
-ENV HTTP_PROXY=${HTTP_PROXY}
-ENV HTTPS_PROXY=${HTTPS_PROXY}
-ENV http_proxy=${http_proxy}
-ENV https_proxy=${https_proxy}
 RUN if [ -n "${HTTP_PROXY}" ]; then echo "Acquire::http::proxy \"${HTTP_PROXY}\";" >> /etc/apt/apt.conf; fi
 RUN if [ -n "${HTTPS_PROXY}" ]; then echo "Acquire::https::proxy \"${HTTPS_PROXY}\";" >> /etc/apt/apt.conf; fi
 RUN if [ -n "${http_proxy}" ]; then echo "Acquire::http::proxy \"${http_proxy}\";" >> /etc/apt/apt.conf; fi

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -1,6 +1,14 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 USER 0
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG http_proxy
+ARG https_proxy
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV http_proxy=${http_proxy}
+ENV https_proxy=${https_proxy}
 RUN if [ -n "${HTTP_PROXY}" ]; then echo "Acquire::http::proxy \"${HTTP_PROXY}\";" >> /etc/apt/apt.conf; fi
 RUN if [ -n "${HTTPS_PROXY}" ]; then echo "Acquire::https::proxy \"${HTTPS_PROXY}\";" >> /etc/apt/apt.conf; fi
 RUN if [ -n "${http_proxy}" ]; then echo "Acquire::http::proxy \"${http_proxy}\";" >> /etc/apt/apt.conf; fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ x-sentry-defaults: &sentry_defaults
     context: ./sentry
     args:
       - SENTRY_IMAGE
+      - HTTP_PROXY
+      - HTTPS_PROXY
+      - http_proxy
+      - https_proxy
   depends_on:
     redis:
       <<: *depends_on-healthy
@@ -655,6 +659,10 @@ services:
       context: ./cron
       args:
         BASE_IMAGE: sentry-self-hosted-local
+        HTTP_PROXY: "${HTTP_PROXY:-}"
+        HTTPS_PROXY: "${HTTPS_PROXY:-}"
+        http_proxy: "${http_proxy:-}"
+        https_proxy: "${https_proxy:-}"
     entrypoint: "/entrypoint.sh"
     command: '"0 0 * * * gosu sentry sentry cleanup --days $SENTRY_EVENT_RETENTION_DAYS"'
   nginx:

--- a/jq/Dockerfile
+++ b/jq/Dockerfile
@@ -2,6 +2,20 @@ FROM debian:bookworm-slim
 
 LABEL MAINTAINER="oss@sentry.io"
 
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG http_proxy
+ARG https_proxy
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV http_proxy=${http_proxy}
+ENV https_proxy=${https_proxy}
+
+RUN if [ -n "${HTTP_PROXY}" ]; then echo "Acquire::http::proxy \"${HTTP_PROXY}\";" >> /etc/apt/apt.conf; fi
+RUN if [ -n "${HTTPS_PROXY}" ]; then echo "Acquire::https::proxy \"${HTTPS_PROXY}\";" >> /etc/apt/apt.conf; fi
+RUN if [ -n "${http_proxy}" ]; then echo "Acquire::http::proxy \"${http_proxy}\";" >> /etc/apt/apt.conf; fi
+RUN if [ -n "${https_proxy}" ]; then echo "Acquire::https::proxy \"${https_proxy}\";" >> /etc/apt/apt.conf; fi
+
 RUN set -x \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq \

--- a/jq/Dockerfile
+++ b/jq/Dockerfile
@@ -6,10 +6,6 @@ ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG http_proxy
 ARG https_proxy
-ENV HTTP_PROXY=${HTTP_PROXY}
-ENV HTTPS_PROXY=${HTTPS_PROXY}
-ENV http_proxy=${http_proxy}
-ENV https_proxy=${https_proxy}
 
 RUN if [ -n "${HTTP_PROXY}" ]; then echo "Acquire::http::proxy \"${HTTP_PROXY}\";" >> /etc/apt/apt.conf; fi
 RUN if [ -n "${HTTPS_PROXY}" ]; then echo "Acquire::https::proxy \"${HTTPS_PROXY}\";" >> /etc/apt/apt.conf; fi

--- a/sentry/Dockerfile
+++ b/sentry/Dockerfile
@@ -1,6 +1,15 @@
 ARG SENTRY_IMAGE
 FROM ${SENTRY_IMAGE}
 
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG http_proxy
+ARG https_proxy
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV http_proxy=${http_proxy}
+ENV https_proxy=${https_proxy}
+
 RUN pip install https://github.com/getsentry/sentry-nodestore-s3/archive/main.zip
 
 COPY . /usr/src/sentry

--- a/sentry/Dockerfile
+++ b/sentry/Dockerfile
@@ -5,10 +5,6 @@ ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG http_proxy
 ARG https_proxy
-ENV HTTP_PROXY=${HTTP_PROXY}
-ENV HTTPS_PROXY=${HTTPS_PROXY}
-ENV http_proxy=${http_proxy}
-ENV https_proxy=${https_proxy}
 
 RUN pip install https://github.com/getsentry/sentry-nodestore-s3/archive/main.zip
 


### PR DESCRIPTION
**Problem**

Deployers building self-hosted behind a corporate HTTP/HTTPS proxy have no way to have that proxy applied during the docker build/docker compose build steps for the jq, sentry, and cron images.

install/dc-detect-version.sh already computes and passes --build-arg HTTP_PROXY=... --build-arg HTTPS_PROXY=... --build-arg http_proxy=... --build-arg https_proxy=... (sourced from .env.custom, the documented proxy override file) to both dcb (docker compose build) and dbuild (docker build, used for jq). However, none of the three Dockerfiles declare these as ARGs, so the values are silently discarded and never reach apt-get/pip inside the build.

In practice this causes builds to fail behind a proxy — for example pip install in sentry/Dockerfile times out trying to reach github.com directly.

**Fix**

Declare and consume the standard proxy build args (HTTP_PROXY, HTTPS_PROXY, http_proxy, https_proxy) in all three Dockerfiles, and forward them from docker-compose.yml:

- jq/Dockerfile, sentry/Dockerfile, cron/Dockerfile: add ARG/ENV declarations for HTTP_PROXY/HTTPS_PROXY/http_proxy/https_proxy right after FROM, so they're available to every subsequent RUN (apt, pip, etc.). jq/Dockerfile and cron/Dockerfile also configure apt's proxy explicitly (Acquire::http::proxy/Acquire::https::proxy) when set, matching the pattern already used elsewhere.
- docker-compose.yml: add HTTP_PROXY/HTTPS_PROXY/http_proxy/https_proxy to x-sentry-defaults.build.args and to the cron/sentry-cleanup service's build.args, since Compose does not forward arbitrary CLI 
- --build-arg names to a service unless they're also declared in that service's own build.args.

No proxy URL or domain is hardcoded anywhere — everything is driven purely by whatever the deployer sets in .env.custom (or their shell environment), exactly as documented in the self-hosted proxy configuration docs. Deployments with no proxy configured are unaffected (ARGs default to empty, if [ -n "..." ] guards skip the apt proxy config).

**Testing**

Validated on an internal self-hosted deployment behind a corporate HTTP proxy:
- Confirmed via a temporary debug RUN env | grep -i proxy that HTTP_PROXY/HTTPS_PROXY/http_proxy/https_proxy are correctly populated inside the sentry image build.
- Confirmed pip install https://github.com/getsentry/sentry-nodestore-s3/archive/main.zip succeeds through the proxy, where it previously timed out.
- Confirmed the jq image build (plain docker build, not Compose) picks up the same args correctly.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

**Legal Boilerplate**

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.