### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -216,8 +216,9 @@ runs:
         node-version: "22.x"
 
     - name: Setup Sentry CLI
-      shell: bash
-      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.4.3" bash
+      uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
+      with:
+        version: "3.4.3"
 
     - name: Install Nodejs dependencies
       shell: bash


### PR DESCRIPTION
## Summary
- The "Setup Sentry CLI" step used `curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="3.4.3" bash`, piping a remote install script directly into a shell.
- Replaced it with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.
- Same pinned version (`3.4.3`) preserved via the action's `version` input.

This is one of two live examples of this new action in use — the other is [sentry-fastlane-plugin#529](https://github.com/getsentry/sentry-fastlane-plugin/pull/529), which is green on all checks.

## Test plan
- [x] Validated `action.yaml` parses correctly
- [ ] Verify the end-to-end test job installs sentry-cli 3.4.3 correctly on this PR

Fixes VULN-2365

🤖 Generated with [Claude Code](https://claude.com/claude-code)