### PR TITLE
fix: stop the right containers for minimize-downtime flag

### DIFF
--- a/install/turn-things-off.sh
+++ b/install/turn-things-off.sh
@@ -1,8 +1,8 @@
 echo "${_group}Turning things off ..."
 
 if [[ -n "$MINIMIZE_DOWNTIME" ]]; then
-  # Stop everything but relay and nginx
-  $dc rm -fsv $($dc config --services | grep -v -E '^(nginx|relay)$')
+  # Stop everything unless databases, relay, web, and nginx
+  $dc down -fsv $($dc config --services | grep -v -E '^(nginx|web|relay|smtp|memcached|redis|postgres|pgbouncer|kafka|clickhouse|seaweedfs)$')
 else
   # Clean up old stuff and ensure nothing is working while we install/update
   if [ "$CONTAINER_ENGINE" = "podman" ]; then

--- a/install/turn-things-off.sh
+++ b/install/turn-things-off.sh
@@ -2,7 +2,7 @@ echo "${_group}Turning things off ..."
 
 if [[ -n "$MINIMIZE_DOWNTIME" ]]; then
   # Stop everything unless databases, relay, web, and nginx
-  $dc down -fsv $($dc config --services | grep -v -E '^(nginx|web|relay|smtp|memcached|redis|postgres|pgbouncer|kafka|clickhouse|seaweedfs)$')
+  $dc down $($dc config --services | grep -v -E '^(nginx|web|relay|smtp|memcached|redis|postgres|pgbouncer|kafka|clickhouse|seaweedfs)$')
 else
   # Clean up old stuff and ensure nothing is working while we install/update
   if [ "$CONTAINER_ENGINE" = "podman" ]; then

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -2,13 +2,12 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
   echo "${_group}Waiting for Sentry to start ..."
 
   # Start the whole setup, except nginx, relay, and web.
-  start_service_and_wait_ready --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay|web)$')
+  start_service_and_wait_ready --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
 
   if [ -n "$($dc ps -q nginx 2>/dev/null)" ]; then
-    # relay and web will be restarted as well, if we restart relay.
-    $dc restart nginx
+    $dc exec -T nginx nginx -s reload || true
   else
-    echo "Nginx container not found, skipping restart."
+    echo "Nginx container not found, skipping reload."
   fi
 
   $CONTAINER_ENGINE run --rm --network="${COMPOSE_PROJECT_NAME}_default" alpine ash \

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -1,19 +1,14 @@
 if [[ "$MINIMIZE_DOWNTIME" ]]; then
   echo "${_group}Waiting for Sentry to start ..."
 
-  # Start the whole setup, except nginx and relay.
-  start_service_and_wait_ready --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
-
-  if [ -n "$($dc ps -q relay 2>/dev/null)" ]; then
-    $dc restart relay
-  else
-    echo "Relay container not found, skipping restart."
-  fi
+  # Start the whole setup, except nginx, relay, and web.
+  start_service_and_wait_ready --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay|web)$')
 
   if [ -n "$($dc ps -q nginx 2>/dev/null)" ]; then
-    $dc exec -T nginx nginx -s reload || true
+    # relay and web will be restarted as well, if we restart relay.
+    $dc restart nginx
   else
-    echo "Nginx container not found, skipping reload."
+    echo "Nginx container not found, skipping restart."
   fi
 
   $CONTAINER_ENGINE run --rm --network="${COMPOSE_PROJECT_NAME}_default" alpine ash \


### PR DESCRIPTION
The `--minimize-downtime` should not remove all databases (postgres, kafka, clickhouse, etc) on `turn-things-off`. Tested this on my instance with `:nightly`. Works well as long as you don't have any wrongdoings on `docker-compose.override.yml` (learned this the hard way)

Closes https://github.com/getsentry/self-hosted/issues/4192