### PR TITLE
ci: Ignore postgres major versions bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       - "@getsentry/security"
     cooldown:
       default-days: 3
+    ignore:
+      - dependency-name: postgres
+        versions:
+          - ">=15"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
So there is no need to ignore all major versions like https://github.com/getsentry/self-hosted/pull/4456.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
