### PR TITLE
chore(deps): bump seaweedfs to 4.40

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,7 +275,7 @@ services:
       retries: 30
   seaweedfs:
     <<: *restart_policy
-    image: "chrislusf/seaweedfs:4.29_large_disk@sha256:e5ca7cc6b61cf5d89a5f85821e0cf115a9765e2d1f27223cbb7722c7837c024e"
+    image: "chrislusf/seaweedfs:4.40_large_disk@sha256:d07aa1dae03c687e0737b86130ded1b18474211a09e85d737fbe5508b8805139"
     entrypoint: "weed"
     command: >-
         mini


### PR DESCRIPTION
Closes https://github.com/getsentry/self-hosted/issues/4417
