### PR TITLE
ci: Ignore kafka major versions bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - dependency-name: postgres
         versions:
           - ">=15"
+      - dependency-name: confluentinc/cp-kafka
+        versions:
+          - ">=8"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Same as https://github.com/getsentry/self-hosted/pull/4457 to prevent PRs like https://github.com/getsentry/self-hosted/pull/4459.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
