### PR TITLE
feat(tasks): Increase kafka_session_timeout_ms in taskbroker

### DIFF
--- a/taskbroker/config.yml
+++ b/taskbroker/config.yml
@@ -1,4 +1,8 @@
 # See https://github.com/getsentry/taskbroker/pull/667 for the config format.
+# The feature-complete stack can temporarily starve Kafka during startup.
+# Self-hosted runs one taskbroker, so fast consumer failover provides little benefit.
+kafka_session_timeout_ms: 60000
+
 kafka_deadletter_topic: taskworker-dlq
 kafka_retry_topic: taskworker
 


### PR DESCRIPTION
This is a another attempt to fix `taskbroker` healthcheck failures in CI like https://github.com/getsentry/taskbroker/pull/779 .

This is useful for users as well, default 6 seconds in current environment is too low.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
