### PR TITLE
ci: Ignore multiple images major versions bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,18 @@ updates:
       - dependency-name: postgres
         versions:
           - ">=15"
+      - dependency-name: valkey/valkey
+        versions:
+          - ">=9"
+      - dependency-name: memcached
+        versions:
+          - ">=2"
+      - dependency-name: edoburu/pgbouncer
+        versions:
+          - ">=2"
+      - dependency-name: chrislusf/seaweedfs
+        versions:
+          - ">=5"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Continuation of https://github.com/getsentry/self-hosted/pull/4462#issuecomment-5274937485 asked by @aldy505 .

Quick note: clickhouse version is specified in `build.args.BASE_IMAGE` of docker-compose.yml, so it's not getting updated by dependabot.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
