### PR TITLE
ci: Ignore kafka > 7.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
           - ">=5"
       - dependency-name: confluentinc/cp-kafka
         versions:
-          - ">=8"
+          - ">=7.7"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Seems like `kafka` is not following semver, let's restrict `dependabot` to report for kafka 7.6 releases for now.

https://github.com/getsentry/self-hosted/pull/4469 failed.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
