### PR TITLE
ref(snuba): Remove obsolete uWSGI environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,8 +113,6 @@ x-snuba-defaults: &snuba_defaults
     CLICKHOUSE_HOST: clickhouse
     DEFAULT_BROKERS: "kafka:9092"
     REDIS_HOST: redis
-    UWSGI_MAX_REQUESTS: "10000"
-    UWSGI_DISABLE_LOGGING: "true"
     SENTRY_KAFKA_MAX_POLL_INTERVAL_MS:
     # Leaving the value empty to just pass whatever is set
     # on the host system (or in the .env file)

--- a/optional-modifications/patches/external-kafka/docker-compose.yml.patch
+++ b/optional-modifications/patches/external-kafka/docker-compose.yml.patch
@@ -24,7 +24,7 @@
    volumes:
      - "sentry-data:/data"
      - "./sentry:/etc/sentry"
-@@ -102,15 +108,20 @@
+@@ -102,13 +108,18 @@
    depends_on:
      clickhouse:
        <<: *depends_on-healthy
@@ -46,9 +46,7 @@
 +    KAFKA_SASL_USERNAME: ${KAFKA_SASL_USERNAME:-}
 +    KAFKA_SASL_PASSWORD: ${KAFKA_SASL_PASSWORD:-}
      REDIS_HOST: redis
-     UWSGI_MAX_REQUESTS: "10000"
-     UWSGI_DISABLE_LOGGING: "true"
-@@ -192,43 +203,7 @@
+@@ -190,43 +201,7 @@
        ADMIN_USERS: postgres,sentry
        MAX_CLIENT_CONN: 10000
  
@@ -93,7 +91,7 @@
    clickhouse:
      <<: [*restart_policy, *pull_policy]
      image: clickhouse-self-hosted-local
-@@ -765,9 +740,8 @@
+@@ -763,9 +738,8 @@
          read_only: true
          source: ./geoip
          target: /geoip
@@ -104,7 +102,7 @@
        redis:
          <<: *depends_on-healthy
        web:
-@@ -776,11 +750,18 @@
+@@ -774,11 +748,18 @@
      <<: [*restart_policy, *pull_policy]
      image: "$TASKBROKER_IMAGE"
      environment:
@@ -128,7 +126,7 @@
        TASKBROKER_DB_PATH: "/opt/sqlite/taskbroker-activations.sqlite"
        TASKBROKER_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
      command: /opt/taskbroker -c /etc/taskbroker/config.yml
-@@ -790,9 +771,6 @@
+@@ -788,9 +769,6 @@
          read_only: true
          source: ./taskbroker
          target: /etc/taskbroker
@@ -138,7 +136,7 @@
    taskscheduler:
      <<: *sentry_defaults
      command: run taskworker-scheduler
-@@ -828,14 +806,23 @@
+@@ -826,14 +804,23 @@
      <<: [*restart_policy, *pull_policy]
      image: "$VROOM_IMAGE"
      environment:
@@ -164,7 +162,7 @@
      healthcheck:
        <<: *healthcheck_defaults
        test:
-@@ -844,9 +831,6 @@
+@@ -842,9 +829,6 @@
          - "-c"
          # Courtesy of https://unix.stackexchange.com/a/234089/108960
          - 'exec 3<>/dev/tcp/127.0.0.1/8085 && echo -e "GET /health HTTP/1.1\r\nhost: 127.0.0.1\r\n\r\n" >&3 && grep OK -s -m 1 <&3'
@@ -174,7 +172,7 @@
      profiles:
        - feature-complete
    uptime-checker:
-@@ -854,7 +838,14 @@
+@@ -852,7 +836,14 @@
      image: "$UPTIME_CHECKER_IMAGE"
      command: run
      environment:
@@ -190,7 +188,7 @@
        UPTIME_CHECKER_REDIS_HOST: redis://redis:6379
        # Set to `true` will allow uptime checks against private IP addresses
        UPTIME_CHECKER_ALLOW_INTERNAL_IPS: "false"
-@@ -866,8 +857,6 @@
+@@ -864,8 +855,6 @@
        #UPTIME_CHECKER_HTTP_CHECKER_DNS_NAMESERVERS: "8.8.8.8,8.8.4.4"
        UPTIME_CHECKER_STATSD_ADDR: ${STATSD_ADDR:-127.0.0.1:8125}
      depends_on:
@@ -199,7 +197,7 @@
        redis:
          <<: *depends_on-healthy
      profiles:
-@@ -881,8 +870,6 @@
+@@ -879,8 +868,6 @@
      external: true
    sentry-redis:
      external: true


### PR DESCRIPTION
## Problem

Snuba migrated from uWSGI to Granian, but the self-hosted Compose configuration still sets `UWSGI_MAX_REQUESTS` and `UWSGI_DISABLE_LOGGING` in `x-snuba-defaults`.

Snuba no longer consumes these variables, so they are stale and may incorrectly suggest that they still affect Snuba process behavior.

Note: While updating the external Kafka patch context, I found that the patch is already outdated against the current `master` and still fails on an unrelated Kafka service removal hunk. That pre-existing issue is outside the scope of this cleanup.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
