### PR TITLE
ref(spans): Run process-segments as a task

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -552,13 +552,6 @@ services:
       <<: *file_healthcheck_defaults
     profiles:
       - feature-complete
-  process-segments:
-    <<: *sentry_defaults
-    command: run consumer process-segments --consumer-group process-segments --auto-offset-reset=earliest --no-strict-offset-reset --healthcheck-file-path /tmp/health.txt --max-poll-interval-ms ${SENTRY_KAFKA_MAX_POLL_INTERVAL_MS:-300000}
-    healthcheck:
-      <<: *file_healthcheck_defaults
-    profiles:
-      - feature-complete
   monitors-clock-tick:
     <<: *sentry_defaults
     command: run consumer monitors-clock-tick --consumer-group monitors-clock-tick --auto-offset-reset=earliest --no-strict-offset-reset --healthcheck-file-path /tmp/health.txt --max-poll-interval-ms ${SENTRY_KAFKA_MAX_POLL_INTERVAL_MS:-300000}

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -519,6 +519,16 @@ CSP_REPORT_ONLY = True
 # if you're using it directly like a CDN instead of using the loader script.
 JS_SDK_LOADER_DEFAULT_SDK_URL = "https://browser.sentry-cdn.com/%s/bundle%s.min.js"
 
+#########
+# Spans #
+#########
+
+# Segments are processed by a taskworker task rather than the dedicated
+# process-segments Kafka consumer, so there is no such consumer in
+# docker-compose.yml. This is set explicitly (rather than relying on the default
+# in sentry) because self-hosted and sentry are released on different cadences.
+SENTRY_OPTIONS["spans.buffer.process-segments-task-rollout-rate"] = 1.0
+
 #####################
 # Insights Settings #
 #####################


### PR DESCRIPTION
Segments are already processed by the `process_segment` task in production.
This sets `spans.buffer.process-segments-task-rollout-rate` to 1.0 and drops the
dedicated `process-segments` Kafka consumer.

The option is set here rather than relying on the default in sentry because
self-hosted and sentry are released on different cadences, so a default change
in sentry would not take effect until the next release.

Sentry counterpart: https://github.com/getsentry/sentry/pull/122555

ref STREAM-1568