### PR TITLE
fix(nginx): re-resolve upstreams so a container restart cannot break ingest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -601,11 +601,19 @@ services:
     ports:
       - "$SENTRY_BIND:80/tcp"
     image: "nginx:1.31.4-alpine"
+    environment:
+      # nginx.conf needs the container engine's DNS address, which differs per engine.
+      # The image reads it from /etc/resolv.conf into NGINX_LOCAL_RESOLVERS and substitutes
+      # it into templates, so nginx.conf is mounted as one and rendered over the image default.
+      # The filter keeps envsubst away from the nginx runtime variables in the config.
+      NGINX_ENTRYPOINT_LOCAL_RESOLVERS: 1
+      NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
+      NGINX_ENVSUBST_FILTER: "^NGINX_LOCAL_RESOLVERS$$"
     volumes:
       - type: bind
         read_only: true
         source: ./nginx.conf
-        target: /etc/nginx/nginx.conf
+        target: /etc/nginx/templates/nginx.conf.template
       - sentry-nginx-cache:/var/cache/nginx
       - sentry-nginx-www:/var/www
     healthcheck:

--- a/nginx.conf
+++ b/nginx.conf
@@ -69,11 +69,12 @@ http {
 	# for the life of the worker process. Docker does not guarantee a container the same address
 	# across starts, so nginx can end up proxying to a container that no longer owns it and
 	# answer every request with 502 until someone restarts nginx by hand.
-	# "resolve" needs a resolver, and 127.0.0.11 is Docker's embedded DNS, which is the only
-	# thing on a Compose network that knows the service names. The nginx image itself assumes it,
-	# see /docker-entrypoint.d/15-local-resolvers.envsh.
+	# "resolve" needs a resolver, and the container engine's own DNS is the only thing on a Compose
+	# network that knows the service names. Its address differs per engine -- 127.0.0.11 on Docker,
+	# the network gateway on Podman -- so it is read from /etc/resolv.conf at startup by
+	# /docker-entrypoint.d/15-local-resolvers.envsh, which is why this file is a template.
 	# There are no AAAA records worth waiting for on a Compose network.
-	resolver 127.0.0.11 valid=10s ipv6=off;
+	resolver ${NGINX_LOCAL_RESOLVERS} valid=10s ipv6=off;
 
 	upstream relay {
 		# "resolve" requires the upstream group in shared memory, hence "zone".

--- a/nginx.conf
+++ b/nginx.conf
@@ -65,13 +65,26 @@ http {
 	proxy_read_timeout 90s;
 	proxy_send_timeout 5s;
 
+	# Without "resolve", nginx looks the service names up once at startup and keeps that address
+	# for the life of the worker process. Docker does not guarantee a container the same address
+	# across starts, so nginx can end up proxying to a container that no longer owns it and
+	# answer every request with 502 until someone restarts nginx by hand.
+	# "resolve" needs a resolver, and 127.0.0.11 is Docker's embedded DNS, which is the only
+	# thing on a Compose network that knows the service names. The nginx image itself assumes it,
+	# see /docker-entrypoint.d/15-local-resolvers.envsh.
+	# There are no AAAA records worth waiting for on a Compose network.
+	resolver 127.0.0.11 valid=10s ipv6=off;
+
 	upstream relay {
-		server relay:3000;
+		# "resolve" requires the upstream group in shared memory, hence "zone".
+		zone relay 64k;
+		server relay:3000 resolve;
 		keepalive 2;
 	}
 
 	upstream sentry {
-		server web:9000;
+		zone sentry 64k;
+		server web:9000 resolve;
 		keepalive 2;
 	}
 


### PR DESCRIPTION
Supersedes #4295, keeping @ilias-115 as co-author. Same fix as #3894 asked for, rescoped around the objections raised there and in #4295.

## Why

nginx resolves the service names inside `upstream { server ... }` exactly once, at startup, and caches the answer for the life of the worker process. Docker does not guarantee a container the same address across starts. So after any restart nginx can be proxying to an address that now belongs to a different container — and it will keep doing that forever, because nothing in nginx ever looks again.

The failure is quiet, which is the part that hurts. `web` and `relay` are separate upstreams, so the UI stays fully functional while every ingest request returns 502. We lost roughly three hours of events to this before a human noticed; no health check on our side could have caught it, because nginx itself was healthy.

#3914 helps but does not close it. It restarts nginx when Compose restarts `relay` or `web`, which covers `docker compose restart` and not much else. Our incident began after a host-level Docker restart, where nginx came up 12 s before `relay` despite `depends_on` — nginx cached the address of whatever container held it at that moment. `condition: service_healthy` is not available either, since `relay` declares no healthcheck.

## The DNS cost, since that was the sticking point

The concern in #3894 was "a DNS lookup every 5 seconds is not a good idea, especially under heavy load". That framing does not apply to `resolve`: re-resolution is driven by a timer per upstream server, never by a request.

With two upstream servers and `valid=10s` the steady state is **0.2 queries/s, total, forever** — the same at 1 req/s as at 10k req/s. Each one goes to the container engine's own DNS on the same host, so there is no network hop and no external resolver involved. Requests never wait on it: nginx keeps serving from the cached address while the timer refreshes in the background.

`valid=10s` rather than 30s or 60s because it bounds the outage, not the load. The load is the same at any value; only the worst-case window during which nginx still points at a dead address changes.

## Where the resolver address comes from

`resolve` needs a `resolver`, and only the container engine's own DNS knows the names `relay` and `web` at all — a resolver from the host's `/etc/resolv.conf` cannot resolve them. Its address is not the same everywhere: `127.0.0.11` on Docker, the network gateway on Podman, which this repo also supports.

So nothing is hardcoded. The nginx image already derives the address from the container's `/etc/resolv.conf` in `/docker-entrypoint.d/15-local-resolvers.envsh` and exports it as `NGINX_LOCAL_RESOLVERS`, but that only reaches the config through `envsubst`. `nginx.conf` is therefore mounted at `/etc/nginx/templates/nginx.conf.template` and rendered over the image default via `NGINX_ENVSUBST_OUTPUT_DIR`. `NGINX_ENVSUBST_FILTER` restricts substitution to that single variable, so the nginx runtime variables in the config (`$remote_addr`, `$request_id`, and the rest) are left alone.

The only user-visible consequence is the bind mount target. Anyone who mounts their own `nginx.conf` over `/etc/nginx/nginx.conf` keeps working exactly as before — the template is simply not rendered for them, and they supply their own `resolver`.

## No image bump needed

`resolve` in nginx OSS landed in 1.27.3, and `docker-compose.yml` currently pins `nginx:1.31.4-alpine`, so this applies to master as-is. It is worth noting for anyone backporting: on the 1.25.4 that older release tags carry, nginx refuses to start with this config.

## Test plan

That the template renders to the engine's actual DNS address, that the nginx runtime variables survive `envsubst`, and that the result is a valid config:

```sh
docker network create resolver-test
docker run --rm --network=resolver-test \
  --add-host=relay:127.0.0.1 --add-host=web:127.0.0.1 \
  --env NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1 \
  --env NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx \
  --env 'NGINX_ENVSUBST_FILTER=^NGINX_LOCAL_RESOLVERS$' \
  --volume="$PWD/nginx.conf:/etc/nginx/templates/nginx.conf.template:ro" \
  --entrypoint=/bin/sh nginx:1.31.4-alpine -c '
    export NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1
    . /docker-entrypoint.d/15-local-resolvers.envsh
    /docker-entrypoint.d/20-envsubst-on-templates.sh
    grep -n "resolver\|remote_addr\|request_id" /etc/nginx/nginx.conf
    nginx -t'
docker network rm resolver-test
```

On a user-defined bridge network that prints `resolver 127.0.0.11 valid=10s ipv6=off;`, leaves `$remote_addr` and `$request_id` untouched, and the config test passes. I have no Podman host to try, so the gateway case rests on `15-local-resolvers.envsh` reading the same `/etc/resolv.conf` nginx would have used anyway — a Podman run in CI would settle it.

The version floor is real, worth noting for anyone backporting:

```sh
docker run --rm --add-host=relay:127.0.0.1 --add-host=web:127.0.0.1 \
  --volume="$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
  nginx:1.25.4-alpine nginx -t   # [emerg] invalid parameter "resolve"
```

Then the behaviour that matters — force `relay` to a new address and confirm ingest survives without touching nginx:

```sh
docker compose up -d
docker compose rm --stop --force relay && docker compose up -d relay
sleep 15
# events keep arriving; before this change every ingest request 502s from here on
```

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

