### PR TITLE
docs: fix python version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Any other contributions beyond those listed above are welcome!
 
 To get started, install these tools:
 1. Docker Engine and Docker Compose (via Docker plugin system). Refer to [Docker Engine installation documentation](https://docs.docker.com/engine/install/). It's recommended to install via the distribution's package manager (`apt` for Debian/Ubuntu, and `dnf` or `yum` for CentOS/Fedora/RHEL).
-2. Python v3.10 or higher.
+2. Python v3.11 or higher.
 3. the `uv` package manager. Refer to [their installation documentation](https://docs.astral.sh/uv/getting-started/installation/).
 4. `prek` for Git pre-commit hooks. Refer to [their installation documentation](https://prek.j178.dev/installation/).
 


### PR DESCRIPTION
Current `pyproject.toml` `requires-python = ">=3.11"`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
