### PR TITLE
Migrate fast-revert workflow to GitHub App token

### DIFF
--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -10,28 +10,36 @@ on:
         required: true
         description: '`name <email>` for triggering user'
 
-# disable all permissions -- we use the PAT's permissions instead
+# Disable the default token permissions; the GitHub App token below supplies access.
 permissions: {}
 
 jobs:
   revert:
     runs-on: ubuntu-latest
+    environment: fast-revert
     if: |
       github.event_name == 'workflow_dispatch' || github.event.label.name == 'Trigger: Revert'
     steps:
+      - name: fast-revert bot token
+        id: fast-revert-bot-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GETSENTRY_FAST_REVERT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.GETSENTRY_FAST_REVERT_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.BUMP_SENTRY_TOKEN }}
-      - uses: getsentry/action-fast-revert@v2
+          token: ${{ steps.fast-revert-bot-token.outputs.token }}
+      - uses: getsentry/action-fast-revert@35b4b6c1f8f91b5911159568b3b15e531b5b8174 # v2.0.1
         with:
           pr: ${{ github.event.number || github.event.inputs.pr }}
           co_authored_by: ${{ github.event.inputs.co_authored_by || format('{0} <{1}+{0}@users.noreply.github.com>', github.event.sender.login, github.event.sender.id) }}
           committer_name: getsentry-bot
           committer_email: bot@sentry.io
-          token: ${{ secrets.BUMP_SENTRY_TOKEN }}
+          token: ${{ steps.fast-revert-bot-token.outputs.token }}
       - name: comment on failure
         env:
-          GITHUB_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.fast-revert-bot-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           REPOSITORY_ID: ${{ github.event.repository.id }}


### PR DESCRIPTION
Update fast-revert to use actions/create-github-app-token with the shared GETSENTRY_FAST_REVERT_BOT credentials.