### PR TITLE
feat(nginx): add an opt-in patch that re-resolves the upstream addresses

### DIFF
--- a/optional-modifications/patches/resolve-upstreams/README.md
+++ b/optional-modifications/patches/resolve-upstreams/README.md
@@ -1,38 +1,17 @@
 # resolve-upstreams
 
-Make nginx re-resolve the `relay` and `web` container addresses instead of caching them for the
-life of a worker process.
+nginx resolves the names in an `upstream` block once, at startup, and keeps the result for the life
+of a worker. When a container is recreated onto a different address, nginx keeps using the old one
+and every request fails until nginx is restarted.
 
-## The problem
+The UI failing is obvious; ingest failing is not. `relay` serves `/api/store/`, `/api/<id>/` and
+`/api/0/relays/`, so events are dropped while the UI keeps answering and nothing reports an error.
 
-nginx resolves the names in an `upstream` block once, at startup, and keeps the result forever. If
-a container is recreated and comes back on a different address, nginx keeps sending traffic to the
-old one. Every request fails until nginx itself is restarted.
+This patch adds `resolve` to both upstreams, the `zone` that `resolve` requires, and a `resolver`
+directive rendered at container start from the container's own `/etc/resolv.conf` — the engine DNS
+address is `127.0.0.11` on Docker but the network gateway on Podman, so it is not hardcoded.
 
-The UI failing is obvious. Ingest failing is not: `relay` serves the `/api/store/`, `/api/<id>/`
-and `/api/0/relays/` routes, so events are dropped while the UI keeps working normally and nothing
-in the stack reports an error.
-
-`docker compose restart relay` alone does not trigger this — the address is usually reused. It
-takes a recreate (`docker compose up -d --force-recreate`, an image upgrade, a host reboot with a
-different container start order, or anything else that lets another container claim the old
-address) for the addresses to actually move.
-
-## What the patch changes
-
-- Adds `resolve` to both `upstream` servers, so nginx re-resolves the name on a timer.
-- Adds `zone <name> 512k`, which `resolve` requires — it needs the upstream group in shared memory.
-- Adds a `resolver` directive pointing at the container engine's own DNS, rendered at container
-  start from `nginx-resolver.conf.template` by the nginx image entrypoint
-  (`NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1`). The address differs per engine: `127.0.0.11` on Docker,
-  the network gateway on Podman. Reading it from the container's `/etc/resolv.conf` keeps the patch
-  engine-agnostic.
-
-`nginx.conf` stays mounted at `/etc/nginx/nginx.conf`, exactly where it is without the patch. The
-generated snippet lands in `conf.d/` and is pulled in with an `include`, so a custom `nginx.conf`
-is neither overwritten nor made unwritable.
-
-## How to apply
+## Apply
 
 From the repository root, then run `./install.sh`:
 
@@ -42,71 +21,25 @@ patch -p0 < optional-modifications/patches/resolve-upstreams/nginx.conf.patch
 patch -p0 < optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch
 ```
 
-The first patch creates a new file. All three belong together: `nginx.conf` will not start without
-the rendered snippet, and the snippet is only rendered if the `docker-compose.yml` changes
-(the environment variable and the template bind mount) are in place.
-
-## Cost
-
-Measured on Docker 28.5.2, `nginx:1.31.4-alpine`, 32 worker processes, with a logging DNS server
-in front of the engine resolver, over 70 seconds:
-
-```
-7 query[A] web
-7 query[A] relay
-```
-
-14 queries, no AAAA. That is ~6 per minute per upstream — one per `valid=10s` window, and only one
-query regardless of how many workers exist or how much traffic flows, because the shared zone means
-a single worker performs the lookup. `ipv6=off` keeps nginx from also asking for AAAA records that
-a default Compose network cannot route.
-
-`valid=10s` is the recovery time. Raise it to cut the (already small) query volume further; the
-cost is a correspondingly longer outage after an address change.
-
-## Verified behaviour
-
-Recovery, with a filler container claiming the old address so it cannot be reused:
-
-```
-web 172.31.7.2 -> 172.31.7.4
-patched:    t2s=502 t4s=502 t6s=502 t8s=200 t10s=200 t12s=200
-unpatched:  t5s=502 t10s=502 t15s=502 t20s=502 t25s=502 t30s=502   (never recovers)
-```
+All three belong together: `nginx.conf` will not start without the rendered snippet, and the snippet
+is only rendered with the `docker-compose.yml` changes in place.
 
 ## Tradeoffs
 
-**A missing upstream no longer stops nginx from starting.** Without the patch, a name that does not
-resolve is fatal and loud:
+`valid=10s` is the recovery time. Measured cost with 32 workers: 6 queries per minute per upstream,
+independent of worker count and traffic, because the shared zone means one worker does the lookup.
 
-```
-nginx: [emerg] host not found in upstream "relay:3000" in /etc/nginx/nginx.conf:69
-```
+An unresolvable upstream no longer stops nginx from starting. That is what lets nginx come up before
+`relay`, but a typo in an upstream name or an unreachable resolver now yields a running container
+serving 502s instead of `[emerg] host not found in upstream`. The healthcheck does not catch it —
+it requests `/`, and `curl` without `-f` exits 0 on a 502.
 
-With `resolve`, nginx starts, logs an error, and serves 502s until the name resolves. That is the
-point — it is what lets nginx come up before `relay` and recover on its own — but it also means a
-typo in an upstream name, or a resolver that is unreachable, produces a healthy-looking container
-serving errors instead of a container that visibly refuses to start. The nginx healthcheck does not
-catch this: it requests `/`, and `curl` without `-f` exits 0 on a 502.
+If the nginx container's `/etc/resolv.conf` has no `nameserver`, nginx refuses to start. An
+unpatched install is also broken in that case, with a different message.
 
-**The resolver address must be discoverable.** If the nginx container's `/etc/resolv.conf` has no
-`nameserver` line, the rendered directive has no address and nginx refuses to start
-(`[emerg] no name servers defined`). Note that an unpatched install is also broken in that
-situation — the static upstreams fail with `host not found in upstream` — so this is a different
-error message rather than a newly broken case.
+Do not bind-mount over `/etc/nginx/conf.d`; the snippet is rendered there.
 
-**Do not bind-mount over `/etc/nginx/conf.d`.** The entrypoint renders the snippet there; if that
-directory is read-only, it aborts before nginx starts.
-
-## Engines
-
-Verified on Docker. The Podman path is engine-agnostic by construction (the address comes from
-`/etc/resolv.conf` rather than being hardcoded) but has not been tested — if you run Podman,
-confirm the rendered `/etc/nginx/conf.d/nginx-resolver.conf` names your aardvark resolver:
-
-```bash
-docker compose exec nginx cat /etc/nginx/conf.d/nginx-resolver.conf
-```
+Verified on Docker. The Podman path is engine-agnostic by construction but untested.
 
 ## Background
 

--- a/optional-modifications/patches/resolve-upstreams/README.md
+++ b/optional-modifications/patches/resolve-upstreams/README.md
@@ -6,6 +6,9 @@ nginx keeps using the old one and answers every request with 502.
 Ingest breaks silently, because `relay` serves `/api/store/`, `/api/<id>/` and `/api/0/relays/`.
 This patch makes nginx re-resolve both names.
 
+`restart: true` on nginx's `depends_on` already restarts nginx after a Compose operation recreates `web` or `relay`.
+Apply this patch only if you also need to survive address changes that no Compose operation causes, such as a crash restart or a Docker daemon restart.
+
 ## Apply
 
 Run these from the repository root, keeping the order and the `&&`.
@@ -37,5 +40,7 @@ A rejected hunk stops the sequence before anything depends on it.
 
 ## Background
 
-- https://github.com/getsentry/self-hosted/issues/3894
-- https://github.com/getsentry/self-hosted/pull/4492
+- [Report of nginx routing to a stale relay address](https://github.com/getsentry/self-hosted/issues/3894)
+- [The `depends_on` policy that covers Compose operations](https://github.com/getsentry/self-hosted/pull/3914)
+- [First attempt at re-resolution, with the discussion that led to this patch](https://github.com/getsentry/self-hosted/pull/4295)
+- [Second attempt, which changed the default configuration](https://github.com/getsentry/self-hosted/pull/4492)

--- a/optional-modifications/patches/resolve-upstreams/README.md
+++ b/optional-modifications/patches/resolve-upstreams/README.md
@@ -1,12 +1,16 @@
 # resolve-upstreams
 
-Make nginx re-resolve `relay` and `web` instead of caching their addresses until it restarts.
-Without this, a recreated container that comes back on a different address 502s every request —
-silently for ingest, since `relay` serves `/api/store/`, `/api/<id>/` and `/api/0/relays/`.
+nginx caches the addresses of `relay` and `web` until it restarts.
+A recreated container can come back on a different address.
+Every request then fails with 502.
+Ingest fails silently, because `relay` serves `/api/store/`, `/api/<id>/` and `/api/0/relays/`.
+This patch makes nginx re-resolve both names instead.
 
 ## Apply
 
-From the repository root, keeping the order and the `&&`, then run `./install.sh`:
+Run from the repository root.
+Keep the order and the `&&`.
+Then run `./install.sh`.
 
 ```bash
 patch -p0 < optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch && \
@@ -18,14 +22,19 @@ A rejected hunk stops the sequence before anything depends on it.
 
 ## Notes
 
-- `valid=10s` is the recovery time. Cost: 6 DNS queries per minute per upstream, regardless of
-  worker count and traffic.
-- An unresolvable upstream no longer stops nginx from starting; it serves 502s instead. The
-  healthcheck does not catch this — it requests `/`, and `curl` without `-f` exits 0 on a 502.
-- nginx will not start if its `/etc/resolv.conf` has no `nameserver`. An unpatched install is also
-  broken in that case, with a different message.
-- Do not bind-mount over `/etc/nginx/conf.d`; the resolver snippet is rendered there.
-- Verified on Docker. The Podman path is engine-agnostic by construction but untested.
+- `valid=10s` is the recovery time.
+  It costs 6 DNS queries per minute per upstream.
+  Worker count and traffic do not change that.
+- An unresolvable upstream no longer stops nginx from starting.
+  It serves 502s instead.
+  The healthcheck does not catch this.
+  It requests `/`, and `curl` without `-f` exits 0 on a 502.
+- nginx will not start if its `/etc/resolv.conf` has no `nameserver`.
+  An unpatched install is also broken in that case, with a different message.
+- Do not bind-mount over `/etc/nginx/conf.d`.
+  The resolver snippet is rendered there.
+- Verified on Docker.
+  The Podman path is engine-agnostic by construction, but untested.
 
 ## Background
 

--- a/optional-modifications/patches/resolve-upstreams/README.md
+++ b/optional-modifications/patches/resolve-upstreams/README.md
@@ -1,15 +1,14 @@
 # resolve-upstreams
 
 nginx caches the addresses of `relay` and `web` until it restarts.
-A recreated container can come back on a different address.
-Every request then fails with 502.
-Ingest fails silently, because `relay` serves `/api/store/`, `/api/<id>/` and `/api/0/relays/`.
-This patch makes nginx re-resolve both names instead.
+A recreated container can return on a different address.
+nginx keeps using the old one and answers every request with 502.
+Ingest breaks silently, because `relay` serves `/api/store/`, `/api/<id>/` and `/api/0/relays/`.
+This patch makes nginx re-resolve both names.
 
 ## Apply
 
-Run from the repository root.
-Keep the order and the `&&`.
+Run these from the repository root, keeping the order and the `&&`.
 Then run `./install.sh`.
 
 ```bash
@@ -22,19 +21,19 @@ A rejected hunk stops the sequence before anything depends on it.
 
 ## Notes
 
-- `valid=10s` is the recovery time.
+- `valid=10s` sets the recovery time.
   It costs 6 DNS queries per minute per upstream.
-  Worker count and traffic do not change that.
+  Worker count and traffic do not affect that.
 - An unresolvable upstream no longer stops nginx from starting.
-  It serves 502s instead.
-  The healthcheck does not catch this.
-  It requests `/`, and `curl` without `-f` exits 0 on a 502.
-- nginx will not start if its `/etc/resolv.conf` has no `nameserver`.
-  An unpatched install is also broken in that case, with a different message.
+  nginx serves 502s instead.
+  The healthcheck misses this, because it requests `/` and `curl` without `-f` exits 0 on a 502.
+- nginx refuses to start if its `/etc/resolv.conf` lists no `nameserver`.
+  An unpatched install also breaks in that case, with a different message.
 - Do not bind-mount over `/etc/nginx/conf.d`.
-  The resolver snippet is rendered there.
-- Verified on Docker.
-  The Podman path is engine-agnostic by construction, but untested.
+  The entrypoint renders the resolver snippet there.
+- Tested on Docker.
+  The patch reads the resolver address from the container, so it should suit Podman, but nobody has
+  tested that.
 
 ## Background
 

--- a/optional-modifications/patches/resolve-upstreams/README.md
+++ b/optional-modifications/patches/resolve-upstreams/README.md
@@ -1,19 +1,12 @@
 # resolve-upstreams
 
-nginx resolves the names in an `upstream` block once, at startup, and keeps the result for the life
-of a worker. When a container is recreated onto a different address, nginx keeps using the old one
-and every request fails until nginx is restarted.
-
-The UI failing is obvious; ingest failing is not. `relay` serves `/api/store/`, `/api/<id>/` and
-`/api/0/relays/`, so events are dropped while the UI keeps answering and nothing reports an error.
-
-This patch adds `resolve` to both upstreams, the `zone` that `resolve` requires, and a `resolver`
-directive rendered at container start from the container's own `/etc/resolv.conf` — the engine DNS
-address is `127.0.0.11` on Docker but the network gateway on Podman, so it is not hardcoded.
+Make nginx re-resolve `relay` and `web` instead of caching their addresses until it restarts.
+Without this, a recreated container that comes back on a different address 502s every request —
+silently for ingest, since `relay` serves `/api/store/`, `/api/<id>/` and `/api/0/relays/`.
 
 ## Apply
 
-From the repository root, then run `./install.sh`:
+From the repository root, keeping the order and the `&&`, then run `./install.sh`:
 
 ```bash
 patch -p0 < optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch && \
@@ -21,28 +14,18 @@ patch -p0 < optional-modifications/patches/resolve-upstreams/nginx-resolver.conf
 patch -p0 < optional-modifications/patches/resolve-upstreams/nginx.conf.patch
 ```
 
-Keep the order and the `&&`. All three belong together — `nginx.conf` will not start without the
-rendered snippet, and the snippet is only rendered with the `docker-compose.yml` changes in place —
-so `nginx.conf` is patched last, after the parts it depends on have succeeded. If one of these files
-has moved upstream and its patch no longer applies, stopping there leaves a working install rather
-than an `nginx.conf` that requires a snippet nothing renders.
+A rejected hunk stops the sequence before anything depends on it.
 
-## Tradeoffs
+## Notes
 
-`valid=10s` is the recovery time. Measured cost with 32 workers: 6 queries per minute per upstream,
-independent of worker count and traffic, because the shared zone means one worker does the lookup.
-
-An unresolvable upstream no longer stops nginx from starting. That is what lets nginx come up before
-`relay`, but a typo in an upstream name or an unreachable resolver now yields a running container
-serving 502s instead of `[emerg] host not found in upstream`. The healthcheck does not catch it —
-it requests `/`, and `curl` without `-f` exits 0 on a 502.
-
-If the nginx container's `/etc/resolv.conf` has no `nameserver`, nginx refuses to start. An
-unpatched install is also broken in that case, with a different message.
-
-Do not bind-mount over `/etc/nginx/conf.d`; the snippet is rendered there.
-
-Verified on Docker. The Podman path is engine-agnostic by construction but untested.
+- `valid=10s` is the recovery time. Cost: 6 DNS queries per minute per upstream, regardless of
+  worker count and traffic.
+- An unresolvable upstream no longer stops nginx from starting; it serves 502s instead. The
+  healthcheck does not catch this — it requests `/`, and `curl` without `-f` exits 0 on a 502.
+- nginx will not start if its `/etc/resolv.conf` has no `nameserver`. An unpatched install is also
+  broken in that case, with a different message.
+- Do not bind-mount over `/etc/nginx/conf.d`; the resolver snippet is rendered there.
+- Verified on Docker. The Podman path is engine-agnostic by construction but untested.
 
 ## Background
 

--- a/optional-modifications/patches/resolve-upstreams/README.md
+++ b/optional-modifications/patches/resolve-upstreams/README.md
@@ -1,0 +1,114 @@
+# resolve-upstreams
+
+Make nginx re-resolve the `relay` and `web` container addresses instead of caching them for the
+life of a worker process.
+
+## The problem
+
+nginx resolves the names in an `upstream` block once, at startup, and keeps the result forever. If
+a container is recreated and comes back on a different address, nginx keeps sending traffic to the
+old one. Every request fails until nginx itself is restarted.
+
+The UI failing is obvious. Ingest failing is not: `relay` serves the `/api/store/`, `/api/<id>/`
+and `/api/0/relays/` routes, so events are dropped while the UI keeps working normally and nothing
+in the stack reports an error.
+
+`docker compose restart relay` alone does not trigger this — the address is usually reused. It
+takes a recreate (`docker compose up -d --force-recreate`, an image upgrade, a host reboot with a
+different container start order, or anything else that lets another container claim the old
+address) for the addresses to actually move.
+
+## What the patch changes
+
+- Adds `resolve` to both `upstream` servers, so nginx re-resolves the name on a timer.
+- Adds `zone <name> 512k`, which `resolve` requires — it needs the upstream group in shared memory.
+- Adds a `resolver` directive pointing at the container engine's own DNS, rendered at container
+  start from `nginx-resolver.conf.template` by the nginx image entrypoint
+  (`NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1`). The address differs per engine: `127.0.0.11` on Docker,
+  the network gateway on Podman. Reading it from the container's `/etc/resolv.conf` keeps the patch
+  engine-agnostic.
+
+`nginx.conf` stays mounted at `/etc/nginx/nginx.conf`, exactly where it is without the patch. The
+generated snippet lands in `conf.d/` and is pulled in with an `include`, so a custom `nginx.conf`
+is neither overwritten nor made unwritable.
+
+## How to apply
+
+From the repository root, then run `./install.sh`:
+
+```bash
+patch -p0 < optional-modifications/patches/resolve-upstreams/nginx-resolver.conf.template.patch
+patch -p0 < optional-modifications/patches/resolve-upstreams/nginx.conf.patch
+patch -p0 < optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch
+```
+
+The first patch creates a new file. All three belong together: `nginx.conf` will not start without
+the rendered snippet, and the snippet is only rendered if the `docker-compose.yml` changes
+(the environment variable and the template bind mount) are in place.
+
+## Cost
+
+Measured on Docker 28.5.2, `nginx:1.31.4-alpine`, 32 worker processes, with a logging DNS server
+in front of the engine resolver, over 70 seconds:
+
+```
+7 query[A] web
+7 query[A] relay
+```
+
+14 queries, no AAAA. That is ~6 per minute per upstream — one per `valid=10s` window, and only one
+query regardless of how many workers exist or how much traffic flows, because the shared zone means
+a single worker performs the lookup. `ipv6=off` keeps nginx from also asking for AAAA records that
+a default Compose network cannot route.
+
+`valid=10s` is the recovery time. Raise it to cut the (already small) query volume further; the
+cost is a correspondingly longer outage after an address change.
+
+## Verified behaviour
+
+Recovery, with a filler container claiming the old address so it cannot be reused:
+
+```
+web 172.31.7.2 -> 172.31.7.4
+patched:    t2s=502 t4s=502 t6s=502 t8s=200 t10s=200 t12s=200
+unpatched:  t5s=502 t10s=502 t15s=502 t20s=502 t25s=502 t30s=502   (never recovers)
+```
+
+## Tradeoffs
+
+**A missing upstream no longer stops nginx from starting.** Without the patch, a name that does not
+resolve is fatal and loud:
+
+```
+nginx: [emerg] host not found in upstream "relay:3000" in /etc/nginx/nginx.conf:69
+```
+
+With `resolve`, nginx starts, logs an error, and serves 502s until the name resolves. That is the
+point — it is what lets nginx come up before `relay` and recover on its own — but it also means a
+typo in an upstream name, or a resolver that is unreachable, produces a healthy-looking container
+serving errors instead of a container that visibly refuses to start. The nginx healthcheck does not
+catch this: it requests `/`, and `curl` without `-f` exits 0 on a 502.
+
+**The resolver address must be discoverable.** If the nginx container's `/etc/resolv.conf` has no
+`nameserver` line, the rendered directive has no address and nginx refuses to start
+(`[emerg] no name servers defined`). Note that an unpatched install is also broken in that
+situation — the static upstreams fail with `host not found in upstream` — so this is a different
+error message rather than a newly broken case.
+
+**Do not bind-mount over `/etc/nginx/conf.d`.** The entrypoint renders the snippet there; if that
+directory is read-only, it aborts before nginx starts.
+
+## Engines
+
+Verified on Docker. The Podman path is engine-agnostic by construction (the address comes from
+`/etc/resolv.conf` rather than being hardcoded) but has not been tested — if you run Podman,
+confirm the rendered `/etc/nginx/conf.d/nginx-resolver.conf` names your aardvark resolver:
+
+```bash
+docker compose exec nginx cat /etc/nginx/conf.d/nginx-resolver.conf
+```
+
+## Background
+
+- https://github.com/getsentry/self-hosted/issues/3894
+- https://github.com/getsentry/self-hosted/pull/4492

--- a/optional-modifications/patches/resolve-upstreams/README.md
+++ b/optional-modifications/patches/resolve-upstreams/README.md
@@ -16,13 +16,16 @@ address is `127.0.0.11` on Docker but the network gateway on Podman, so it is no
 From the repository root, then run `./install.sh`:
 
 ```bash
-patch -p0 < optional-modifications/patches/resolve-upstreams/nginx-resolver.conf.template.patch
+patch -p0 < optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch && \
+patch -p0 < optional-modifications/patches/resolve-upstreams/nginx-resolver.conf.template.patch && \
 patch -p0 < optional-modifications/patches/resolve-upstreams/nginx.conf.patch
-patch -p0 < optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch
 ```
 
-All three belong together: `nginx.conf` will not start without the rendered snippet, and the snippet
-is only rendered with the `docker-compose.yml` changes in place.
+Keep the order and the `&&`. All three belong together — `nginx.conf` will not start without the
+rendered snippet, and the snippet is only rendered with the `docker-compose.yml` changes in place —
+so `nginx.conf` is patched last, after the parts it depends on have succeeded. If one of these files
+has moved upstream and its patch no longer applies, stopping there leaves a working install rather
+than an `nginx.conf` that requires a snippet nothing renders.
 
 ## Tradeoffs
 

--- a/optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch
+++ b/optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch
@@ -1,13 +1,6 @@
 --- docker-compose.yml	2026-08-31 09:58:28.827732343 +0200
-+++ docker-compose.resolve-upstreams.yml	2026-08-31 09:59:13.197843697 +0200
-@@ -601,11 +601,17 @@
-     ports:
-       - "$SENTRY_BIND:80/tcp"
-     image: "nginx:1.31.4-alpine"
-+    environment:
-+      NGINX_ENTRYPOINT_LOCAL_RESOLVERS: 1
-     volumes:
-       - type: bind
++++ docker-compose.resolve-upstreams.yml	2026-08-31 10:21:46.281494103 +0200
+@@ -606,8 +606,14 @@
          read_only: true
          source: ./nginx.conf
          target: /etc/nginx/nginx.conf
@@ -17,4 +10,8 @@
 +        target: /etc/nginx/templates/nginx-resolver.conf.template
        - sentry-nginx-cache:/var/cache/nginx
        - sentry-nginx-www:/var/www
++    environment:
++      NGINX_ENTRYPOINT_LOCAL_RESOLVERS: 1
      healthcheck:
+       <<: *healthcheck_defaults
+       test:

--- a/optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch
+++ b/optional-modifications/patches/resolve-upstreams/docker-compose.yml.patch
@@ -1,0 +1,20 @@
+--- docker-compose.yml	2026-08-31 09:58:28.827732343 +0200
++++ docker-compose.resolve-upstreams.yml	2026-08-31 09:59:13.197843697 +0200
+@@ -601,11 +601,17 @@
+     ports:
+       - "$SENTRY_BIND:80/tcp"
+     image: "nginx:1.31.4-alpine"
++    environment:
++      NGINX_ENTRYPOINT_LOCAL_RESOLVERS: 1
+     volumes:
+       - type: bind
+         read_only: true
+         source: ./nginx.conf
+         target: /etc/nginx/nginx.conf
++      - type: bind
++        read_only: true
++        source: ./nginx-resolver.conf.template
++        target: /etc/nginx/templates/nginx-resolver.conf.template
+       - sentry-nginx-cache:/var/cache/nginx
+       - sentry-nginx-www:/var/www
+     healthcheck:

--- a/optional-modifications/patches/resolve-upstreams/nginx-resolver.conf.template.patch
+++ b/optional-modifications/patches/resolve-upstreams/nginx-resolver.conf.template.patch
@@ -1,0 +1,4 @@
+--- /dev/null	2026-08-27 11:01:02.392055778 +0200
++++ nginx-resolver.conf.template	2026-08-31 09:59:17.962753633 +0200
+@@ -0,0 +1 @@
++resolver ${NGINX_LOCAL_RESOLVERS} ipv6=off valid=10s;

--- a/optional-modifications/patches/resolve-upstreams/nginx.conf.patch
+++ b/optional-modifications/patches/resolve-upstreams/nginx.conf.patch
@@ -1,11 +1,10 @@
---- nginx.conf	2026-08-31 09:58:28.827732343 +0200
-+++ nginx.resolve-upstreams.conf	2026-08-31 09:59:13.197674745 +0200
-@@ -65,13 +65,18 @@
+--- nginx.conf
++++ nginx.resolve-upstreams.conf
+@@ -65,13 +65,17 @@
  	proxy_read_timeout 90s;
  	proxy_send_timeout 5s;
  
-+	# See optional-modifications/patches/resolve-upstreams/README.md
-+	include /etc/nginx/conf.d/nginx-resolver.conf;
++	include /etc/nginx/conf.d/nginx-resolver.conf; # see optional-modifications/patches/resolve-upstreams
 +
  	upstream relay {
 -		server relay:3000;

--- a/optional-modifications/patches/resolve-upstreams/nginx.conf.patch
+++ b/optional-modifications/patches/resolve-upstreams/nginx.conf.patch
@@ -1,0 +1,23 @@
+--- nginx.conf	2026-08-31 09:58:28.827732343 +0200
++++ nginx.resolve-upstreams.conf	2026-08-31 09:59:13.197674745 +0200
+@@ -65,13 +65,18 @@
+ 	proxy_read_timeout 90s;
+ 	proxy_send_timeout 5s;
+ 
++	# See optional-modifications/patches/resolve-upstreams/README.md
++	include /etc/nginx/conf.d/nginx-resolver.conf;
++
+ 	upstream relay {
+-		server relay:3000;
++		zone relay 512k;
++		server relay:3000 resolve;
+ 		keepalive 2;
+ 	}
+ 
+ 	upstream sentry {
+-		server web:9000;
++		zone sentry 512k;
++		server web:9000 resolve;
+ 		keepalive 2;
+ 	}
+ 


### PR DESCRIPTION
Adds an opt-in patch that makes nginx re-resolve `relay` and `web`, under `optional-modifications/patches/` next to `external-kafka`. Nothing changes for anyone who does not apply it.

@aminvakil, this is the shape you offered to review in https://github.com/getsentry/self-hosted/pull/4295#issuecomment-4325891462:

> I agree that this could be an opt-in behaviour, but I'll be happy to review your PR regarding that, but I think in current scope of project and `nginx.conf` being tracked by git, you should probably write a install script which checks an env or something like that

A patch avoids the install-script env check you disliked, and it is how this repository already handles opt-in edits to git-tracked files.

#4492 changed the default configuration and you rejected that. It stays closed. Its branch now carries a cleaned-up single commit for anyone who wants the same change without the patch indirection.

## Scope, corrected

I previously argued on #4295 that #3914 does not close the gap because our own outage came from a host-level Docker restart. That was wrong, and I have corrected it there. Our `docker inspect` evidence shows a plain `docker compose down` / `up -d`, which is exactly the case `restart: true` covers. We hit it only because our pinned version predates #3914.

So this patch is not for the case #3914 already handles. It is for address changes that no Compose operation causes: a crash restart, or a Docker daemon restart. The README says so, so a reader can tell whether it applies to them.

We also took an unclean VM hard reset on unpatched nginx and the failure did **not** reproduce, because a reboot starts containers rather than recreating them. I am not claiming evidence for the remaining gap beyond the mechanism.

## Answering the earlier objections

- **DNS cost.** `valid=10s` costs about six queries per minute per upstream against the engine's embedded DNS. A per-upstream timer drives it, so worker count and request volume do not affect it. Measured with 32 workers: 14 A queries in 70 s, zero AAAA.
- **Hardcoding `127.0.0.11`.** Dropped. It is Docker-only; Podman answers on the network gateway. The entrypoint reads the address from the container's own `/etc/resolv.conf` instead.
- **Zone size.** `512k`, not `64k`. nginx requires at least eight system pages, so `64k` refuses to start on 64 KiB-page hosts such as RHEL 9 on arm64.
- **Overriding `nginx.conf`.** The resolver lands in a separate include, so the `/etc/nginx/nginx.conf` mount target is unchanged and existing overrides keep working.

## Test plan

Applied against this branch on current `master`: all three hunks apply with no `.rej`, `docker compose config` passes, and the entrypoint renders `resolver <address> ipv6=off valid=10s` and `nginx -t` succeeds.

Behaviour verified on Docker with the patch applied: baseline 200; recreating `relay` onto a new address recovers in 4 s without touching nginx; `nginx -s reload` keeps serving; an upstream absent at startup yields 502 until it appears rather than refusing to start; two nameservers render and validate; no AAAA queries and no unreachable-peer errors.

Not tested on Podman. The patch reads the resolver from the container rather than assuming Docker's address, so it should work, but I have no Podman host to confirm on.

Credit to @ilias-115, whose #4295 established the mechanism.